### PR TITLE
refactor: extract OpenEditor into internal/editor, out of the TUI package

### DIFF
--- a/internal/actions/create/message.go
+++ b/internal/actions/create/message.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/editor"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -14,7 +14,7 @@ func getCommitMessage(ctx *app.Context) (string, error) {
 		return "", err
 	}
 
-	msg, err := tui.OpenEditor(template, "COMMIT_EDITMSG-*")
+	msg, err := editor.Open(template, "COMMIT_EDITMSG-*")
 	if err != nil {
 		return "", err
 	}

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/editor"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -173,7 +173,7 @@ func showDescription(ctx *app.Context, branch engine.Branch, stackRoot string) e
 func openEditor(existing *git.StackDescription) (*git.StackDescription, error) {
 	template := buildEditorTemplate(existing)
 
-	content, err := tui.OpenEditor(template, "STACK_DESCRIPTION-*")
+	content, err := editor.Open(template, "STACK_DESCRIPTION-*")
 	if err != nil {
 		return nil, fmt.Errorf("editor failed: %w", err)
 	}

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/editor"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
@@ -119,7 +120,7 @@ func ReorderAction(ctx *app.Context) error {
 		out.Debug("reorder: editor content prepared (%d bytes)", len(editorContent))
 
 		// Open editor
-		editedContent, err := tui.OpenEditor(editorContent, "stackit-reorder-*.txt")
+		editedContent, err := editor.Open(editorContent, "stackit-reorder-*.txt")
 		if err != nil {
 			out.Debug("reorder: failed to open editor: %v", err)
 			return fmt.Errorf("failed to open editor: %w", err)

--- a/internal/actions/submit/submit_metadata.go
+++ b/internal/actions/submit/submit_metadata.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/editor"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/pr"
@@ -36,7 +37,7 @@ func GetPRBody(branch engine.Branch, editInline bool, existingBody string) (stri
 		return body, nil
 	}
 
-	return tui.OpenEditor(body, "stackit-pr-description-*.md")
+	return editor.Open(body, "stackit-pr-description-*.md")
 }
 
 // GetReviewers gets reviewers from flag or prompts user

--- a/internal/cli/branch/split_handlers.go
+++ b/internal/cli/branch/split_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/actions/split"
 	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/editor"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
@@ -199,7 +200,7 @@ func (h *TUISplitHandler) PromptCommitMessage(defaultMsg string) (string, error)
 		defer h.runner.Resume()
 	}
 
-	msg, err := tui.OpenEditor(defaultMsg, "COMMIT_EDITMSG-*")
+	msg, err := editor.Open(defaultMsg, "COMMIT_EDITMSG-*")
 	if err != nil {
 		return "", err
 	}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1,4 +1,8 @@
-package tui
+// Package editor opens the user's configured text editor on a temporary file
+// and returns the edited content. It is intentionally separate from internal/tui
+// so that callers needing only an editor (not a Bubble Tea UI) don't depend on
+// the heavier TUI package.
+package editor
 
 import (
 	"fmt"
@@ -9,25 +13,29 @@ import (
 	"github.com/getstackit/stackit/internal/utils"
 )
 
-// OpenEditor opens the user's preferred editor with the given initial content.
-// It returns the edited content or an error.
-func OpenEditor(initialContent, filenamePattern string) (string, error) {
-	// Get editor from environment first
-	// Precedence: GIT_EDITOR > EDITOR
+// Open opens the user's preferred editor with the given initial content and
+// returns the edited content, or an error.
+//
+// Editor precedence: GIT_EDITOR > EDITOR > git config core.editor > vi.
+// When no editor is set in the environment, it first checks that interactive
+// use is allowed (so it doesn't hang in CI / non-interactive contexts).
+func Open(initialContent, filenamePattern string) (string, error) {
+	// Get editor from environment first. Precedence: GIT_EDITOR > EDITOR.
 	editor := os.Getenv("GIT_EDITOR")
 	if editor == "" {
 		editor = os.Getenv("EDITOR")
 	}
 
-	// If no editor is explicitly set in the environment, we check if we're allowed
-	// to proceed with interactive defaults. This prevents hangs in non-interactive
-	// environments (like CI) while allowing tests to provide a non-interactive editor script.
+	// If no editor is explicitly set in the environment, check whether we're
+	// allowed to proceed with interactive defaults. This prevents hangs in
+	// non-interactive environments (like CI) while allowing tests to provide a
+	// non-interactive editor script via the environment.
 	if editor == "" {
-		if err := CheckInteractiveAllowed(); err != nil {
+		if err := utils.CheckInteractiveAllowed(); err != nil {
 			return "", err
 		}
 
-		// Try to get from git config
+		// Try to get from git config.
 		output, err := exec.Command("git", "config", "--get", "core.editor").Output()
 		if err == nil && len(output) > 0 {
 			editor = strings.TrimSpace(string(output))
@@ -35,17 +43,17 @@ func OpenEditor(initialContent, filenamePattern string) (string, error) {
 	}
 
 	if editor == "" {
-		editor = "vi" // Default to vi
+		editor = "vi" // Default to vi.
 	}
 
-	// Create temporary file
+	// Create temporary file.
 	tmpFile, err := os.CreateTemp("", filenamePattern)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	// Write initial content
+	// Write initial content.
 	if _, err := tmpFile.WriteString(initialContent); err != nil {
 		return "", fmt.Errorf("failed to write temp file: %w", err)
 	}
@@ -53,7 +61,7 @@ func OpenEditor(initialContent, filenamePattern string) (string, error) {
 		return "", fmt.Errorf("failed to close temp file: %w", err)
 	}
 
-	// Open editor
+	// Open editor.
 	cmd, err := utils.BuildEditorCommand(editor, tmpFile.Name())
 	if err != nil {
 		return "", fmt.Errorf("failed to build editor command: %w", err)
@@ -66,7 +74,7 @@ func OpenEditor(initialContent, filenamePattern string) (string, error) {
 		return "", fmt.Errorf("editor exited with error: %w", err)
 	}
 
-	// Read edited content
+	// Read edited content.
 	content, err := os.ReadFile(tmpFile.Name())
 	if err != nil {
 		return "", fmt.Errorf("failed to read edited file: %w", err)

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -116,15 +116,15 @@ var defaultSelectionKeys = selectionKeys{
 	),
 }
 
-// ErrInteractiveDisabled is returned when interactive prompts are disabled
-var ErrInteractiveDisabled = fmt.Errorf("interactive prompts are disabled (running with --no-interactive or not in a TTY)")
+// ErrInteractiveDisabled is returned when interactive prompts are disabled.
+// Re-exported from utils so existing tui callers (and errors.Is checks) keep
+// working while the canonical definition lives in the lower layer.
+var ErrInteractiveDisabled = utils.ErrInteractiveDisabled
 
-// CheckInteractiveAllowed returns an error if interactive mode is disabled
+// CheckInteractiveAllowed returns an error if interactive mode is disabled.
+// Delegates to utils.CheckInteractiveAllowed.
 func CheckInteractiveAllowed() error {
-	if !utils.IsInteractive() {
-		return ErrInteractiveDisabled
-	}
-	return nil
+	return utils.CheckInteractiveAllowed()
 }
 
 // textInputModel is a simple text input prompt model

--- a/internal/utils/interactive.go
+++ b/internal/utils/interactive.go
@@ -1,0 +1,16 @@
+package utils
+
+import "errors"
+
+// ErrInteractiveDisabled is returned when interactive prompts are disabled
+// (running with --no-interactive or not in a TTY).
+var ErrInteractiveDisabled = errors.New("interactive prompts are disabled (running with --no-interactive or not in a TTY)")
+
+// CheckInteractiveAllowed returns ErrInteractiveDisabled when interactive
+// prompts are not available, and nil otherwise.
+func CheckInteractiveAllowed() error {
+	if !IsInteractive() {
+		return ErrInteractiveDisabled
+	}
+	return nil
+}


### PR DESCRIPTION

tui.OpenEditor is exec-based (launches $EDITOR on a temp file) — it has no
Bubble Tea dependency and was only in internal/tui by accident of placement.
Move it to a new lightweight internal/editor package (editor.Open) so callers
that just need an editor don't pull in the heavy TUI package.

Also move the small interactivity helpers it needs — CheckInteractiveAllowed
and ErrInteractiveDisabled — down to internal/utils (next to IsInteractive),
and re-export them from internal/tui so existing tui callers and errors.Is
checks are unchanged (same error var).

Updates all five OpenEditor call sites. create/message and describe now have
no internal/tui import at all (12 -> 10 tui-importing action files);
reorder, submit_metadata, and the split CLI handler keep tui for their
genuine Bubble Tea prompts. Behavior preserved (lint, tui/utils unit tests,
integration 494).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1242** 👈
  * **PR #1241**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->