### PR TITLE
feat: expose CommitCountBetween on the engine

### DIFF
--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -56,6 +56,14 @@ func (e *engineImpl) BatchDivergencePoints(branches Branches) RevisionMap {
 	}))
 }
 
+// CommitCountBetween returns how many commits are in (base, head]. It is the
+// exported entry point to the cached counter for callers that have two plain
+// revisions rather than a branch set — e.g. reporting how far trunk moved
+// during a sync.
+func (e *engineImpl) CommitCountBetween(base, head string) (int, error) {
+	return e.commitCountBetween(git.RevRange{Base: base, Head: head})
+}
+
 // commitCountBetween returns the commit count in (base, head], using the
 // (base, head)-keyed cache. It takes pre-resolved revisions so batched callers
 // need not re-resolve a branch's head.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -116,6 +116,10 @@ type BranchInfo interface {
 	// additions/deletions) for every branch in one batched pass — a use-case
 	// bundle over the per-concern readers, for annotation builders.
 	BatchBranchStats(branches Branches) map[string]BranchStat
+	// CommitCountBetween returns how many commits are in (base, head]. Backed by
+	// the same content-keyed cache as the batched readers, so repeated calls for
+	// the same pair are free.
+	CommitCountBetween(base, head string) (int, error)
 }
 
 // GitDiffer handles diff and merge operations


### PR DESCRIPTION

The cached commit counter behind the batched branch readers was private, so
callers holding two plain revisions rather than a branch set had no way to ask
"how many commits are between these". Sync wants exactly that, to report how
far trunk moved during a pull.

Reuses the existing content-keyed cache, so repeated calls for the same pair
cost nothing.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1482** 👈
  * **PR #1483**
    * **PR #1485**
      * **PR #1484**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->