### PR TITLE
refactor: move DisplayBranchName into style, add Bold/MarkNote/StepPips

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -91,7 +91,7 @@ func (p *planPrinter) SetStack(stack submit.StackSnapshot) {
 
 // decoratedName is the display name plus scope and worktree annotations.
 func (p *planPrinter) decoratedName(branchName string) string {
-	name := submitComponent.DisplayBranchName(branchName)
+	name := style.DisplayBranchName(branchName)
 	if scope := p.scopes[branchName]; scope != "" {
 		name += " [" + scope + "]"
 	}
@@ -237,7 +237,7 @@ func (p *planPrinter) printSoloLine(ev submit.BranchPlanEvent) {
 // back to the trunk name.
 func (p *planPrinter) soloBase(branchName string) string {
 	if parent := p.parents[branchName]; parent != "" {
-		return submitComponent.DisplayBranchName(parent)
+		return style.DisplayBranchName(parent)
 	}
 	if p.trunk != "" {
 		return p.trunk
@@ -448,7 +448,7 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			if ref := submitComponent.PRRef(item.toSubmitItem()); ref != "" {
 				detail = ref + " " + actionDone
 			}
-			h.Output.Info("  ✓ %s %s", submitComponent.DisplayBranchName(ev.BranchName), detail)
+			h.Output.Info("  ✓ %s %s", style.DisplayBranchName(ev.BranchName), detail)
 			// A newly created PR is the one the user needs to open; updated
 			// PRs rarely need their URL re-pasted.
 			if item.action == engine.SubmitActionCreate && item.url != "" {
@@ -460,11 +460,11 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				h.Output.Info("  ✗ failed: %v", ev.Error)
 				return
 			}
-			h.Output.Info("  ✗ %s failed: %v", submitComponent.DisplayBranchName(ev.BranchName), ev.Error)
+			h.Output.Info("  ✗ %s failed: %v", style.DisplayBranchName(ev.BranchName), ev.Error)
 		}
 
 	case submit.BranchWarningEvent:
-		h.Output.Warn("%s: %s", submitComponent.DisplayBranchName(ev.BranchName), ev.Warning)
+		h.Output.Warn("%s: %s", style.DisplayBranchName(ev.BranchName), ev.Warning)
 
 	case submit.GitHubStackSyncedEvent:
 		h.Output.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(ev.Action), ev.Number, formatGitHubStackPRs(ev.PullRequests))
@@ -666,7 +666,7 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			})
 			return
 		}
-		h.out.Warn("%s: %s", submitComponent.DisplayBranchName(ev.BranchName), ev.Warning)
+		h.out.Warn("%s: %s", style.DisplayBranchName(ev.BranchName), ev.Warning)
 
 	case submit.GitHubStackSyncedEvent:
 		if h.runner.IsRunning() {

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -7,35 +7,14 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"charm.land/lipgloss/v2"
 
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 const defaultSubmitWidth = 80
-
-// DisplayBranchName returns a compact branch name for submit output.
-func DisplayBranchName(branchName string) string {
-	parts := strings.Split(branchName, "/")
-	if len(parts) >= 3 && isTimestampSegment(parts[1]) {
-		return strings.Join(parts[2:], "/")
-	}
-	return branchName
-}
-
-func isTimestampSegment(s string) bool {
-	if len(s) < 12 {
-		return false
-	}
-	for _, r := range s {
-		if !unicode.IsDigit(r) {
-			return false
-		}
-	}
-	return true
-}
 
 // TruncateMiddle shortens s to maxWidth display cells, preserving both ends.
 func TruncateMiddle(s string, maxWidth int) string {
@@ -101,7 +80,7 @@ func FormatCompactRow(item Item, width int, spinnerView string, styles Styles) s
 	icon, detail := rowParts(item, spinnerView, styles)
 	fixedWidth := lipgloss.Width("  "+icon+" ") + lipgloss.Width(detail) + 1
 	nameWidth := max(1, width-fixedWidth)
-	plainName := TruncateMiddle(DisplayBranchName(item.BranchName), nameWidth)
+	plainName := TruncateMiddle(style.DisplayBranchName(item.BranchName), nameWidth)
 	name := styles.BranchStyle.Render(plainName)
 
 	if detail == "" {
@@ -248,7 +227,7 @@ func hyperlink(url, text string) string {
 func FormatFinalList(items []Item) string {
 	rows := make([]string, 0, len(items))
 	for _, item := range items {
-		name := DisplayBranchName(item.BranchName)
+		name := style.DisplayBranchName(item.BranchName)
 		switch item.Status {
 		case StatusError:
 			rows = append(rows, fmt.Sprintf("✗ %s — %s", name, errorText(item.Error)))
@@ -419,7 +398,7 @@ func FormatFailureSummary(items []Item) string {
 		if item.Status != StatusError {
 			continue
 		}
-		rows = append(rows, fmt.Sprintf("✗ %s — %s", DisplayBranchName(item.BranchName), errorText(item.Error)))
+		rows = append(rows, fmt.Sprintf("✗ %s — %s", style.DisplayBranchName(item.BranchName), errorText(item.Error)))
 	}
 	if len(rows) == 0 {
 		return ""

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -12,17 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDisplayBranchNameStripsStackitPrefix(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t,
-		"guard-runner.repoRoot-reads-with-repoMu-to-fix",
-		DisplayBranchName("jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"))
-	require.Equal(t,
-		"refactor-unify-editor-command-launching",
-		DisplayBranchName("refactor-unify-editor-command-launching"))
-}
-
 func TestFormatCompactRowOmitsInlineURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Model is the bubbletea model for submit progress.
@@ -82,7 +83,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case WarningMsg:
-		m.Warnings = append(m.Warnings, fmt.Sprintf("⚠️  %s: %s", DisplayBranchName(msg.BranchName), msg.Warning))
+		m.Warnings = append(m.Warnings, fmt.Sprintf("⚠️  %s: %s", style.DisplayBranchName(msg.BranchName), msg.Warning))
 		return m, nil
 
 	case ProgressUpdateMsg:

--- a/internal/tui/style/branchname.go
+++ b/internal/tui/style/branchname.go
@@ -1,0 +1,32 @@
+package style
+
+import (
+	"strings"
+	"unicode"
+)
+
+// DisplayBranchName returns a compact branch name for command output. Branches
+// created by `stackit create` are named `<user>/<timestamp>/<slug>`; the first
+// two segments carry no information a reader needs, and they dominate the line
+// width when a name appears next to its parent or a PR number. The full name is
+// still used anywhere the output is meant to be copy-pasted (e.g. the
+// `st restack <branch>` advice line).
+func DisplayBranchName(branchName string) string {
+	parts := strings.Split(branchName, "/")
+	if len(parts) >= 3 && isTimestampSegment(parts[1]) {
+		return strings.Join(parts[2:], "/")
+	}
+	return branchName
+}
+
+func isTimestampSegment(s string) bool {
+	if len(s) < 12 {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/style/branchname_test.go
+++ b/internal/tui/style/branchname_test.go
@@ -1,0 +1,50 @@
+package style
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisplayBranchName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strips user and timestamp segments",
+			input:    "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix",
+			expected: "guard-runner.repoRoot-reads-with-repoMu-to-fix",
+		},
+		{
+			name:     "keeps slashes in the slug",
+			input:    "jonnii/20260605032227/extract-OpenEditor-into-internal/editor-out-of",
+			expected: "extract-OpenEditor-into-internal/editor-out-of",
+		},
+		{
+			name:     "leaves plain names alone",
+			input:    "refactor-unify-editor-command-launching",
+			expected: "refactor-unify-editor-command-launching",
+		},
+		{
+			name:     "leaves non-timestamp middle segments alone",
+			input:    "feature/auth/login",
+			expected: "feature/auth/login",
+		},
+		{
+			name:     "leaves short digit segments alone",
+			input:    "release/2026/patch",
+			expected: "release/2026/patch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, DisplayBranchName(tt.input))
+		})
+	}
+}

--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -138,6 +138,12 @@ func ColorNeedsRestack(text string) string {
 		Render(text)
 }
 
+// Bold renders text bold with no color of its own. Used for section headers,
+// where bold alone is enough hierarchy against indented rows.
+func Bold(text string) string {
+	return lipgloss.NewStyle().Bold(true).Render(text)
+}
+
 // ColorDim makes text dim/gray (adaptive to terminal background)
 func ColorDim(text string) string {
 	return lipgloss.NewStyle().

--- a/internal/tui/style/markers.go
+++ b/internal/tui/style/markers.go
@@ -1,6 +1,10 @@
 package style
 
-import "charm.land/lipgloss/v2"
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
 
 // Status markers lead individual item rows in streaming and TUI output (the
 // lines printed beneath a phase header). Each glyph is a single display cell, so
@@ -17,7 +21,45 @@ const (
 	GlyphWarning = "⚠"
 	// GlyphProgress marks an item whose work has started but not yet finished.
 	GlyphProgress = "→"
+	// GlyphNote marks a consequence worth pointing out — a change the reader
+	// could not have predicted, such as a branch being reparented.
+	GlyphNote = "↳"
+	// GlyphStepDone marks a finished or active step in a pipeline indicator.
+	GlyphStepDone = "●"
+	// GlyphStepPending marks a step a pipeline has not reached yet.
+	GlyphStepPending = "○"
 )
+
+// StepPips renders a fixed-length pipeline position as pips — e.g. "●●●●○" for
+// step 4 of 5. Steps before the current one take the completed color, the
+// current one takes the spinner's color so it reads as part of the active line,
+// and steps not yet reached stay dim.
+//
+// This is for a pipeline whose stages are known up front, where the useful
+// signal is "how far along the sequence are we". It deliberately says nothing
+// about how much work each stage holds: a stage is one pip whether it touches
+// one branch or twenty.
+func StepPips(current, total int) string {
+	if total <= 0 || current <= 0 {
+		return ""
+	}
+
+	done := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSuccess))
+	active := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary))
+
+	var b strings.Builder
+	for i := 1; i <= total; i++ {
+		switch {
+		case i < current:
+			b.WriteString(done.Render(GlyphStepDone))
+		case i == current:
+			b.WriteString(active.Render(GlyphStepDone))
+		default:
+			b.WriteString(DimStyle().Render(GlyphStepPending))
+		}
+	}
+	return b.String()
+}
 
 // MarkSuccess returns the green ✓ shown on completed item rows.
 func MarkSuccess() string {
@@ -32,4 +74,11 @@ func MarkWarning() string {
 // MarkProgress returns the dimmed → shown on in-progress item rows.
 func MarkProgress() string {
 	return DimStyle().Render(GlyphProgress)
+}
+
+// MarkNote returns the ↳ shown on rows reporting a consequence the reader could
+// not have predicted. It takes the accent color rather than a status color: a
+// note is neither success nor a problem, it is something to know.
+func MarkNote() string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorAccent)).Render(GlyphNote)
 }

--- a/internal/tui/style/markers_test.go
+++ b/internal/tui/style/markers_test.go
@@ -1,0 +1,34 @@
+package style
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepPips(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		current  int
+		total    int
+		expected string
+	}{
+		{"first step", 1, 5, "●○○○○"},
+		{"middle step", 3, 5, "●●●○○"},
+		{"last step", 5, 5, "●●●●●"},
+		{"single step", 1, 1, "●"},
+		{"zero total renders nothing", 0, 0, ""},
+		{"zero current renders nothing", 0, 5, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Strip color: the pip pattern is the contract, the palette is not.
+			assert.Equal(t, tt.expected, ansi.Strip(StepPips(tt.current, tt.total)))
+		})
+	}
+}


### PR DESCRIPTION

DisplayBranchName lived in the submit TUI component but is not submit-specific:
it strips the generated `<user>/<timestamp>/` prefix that dominates line width
wherever a branch name appears next to a parent or a PR number. Sync needs the
same treatment, and importing a submit component from the sync path would be the
wrong direction, so it moves next to ColorBranchName.

Also adds three primitives the sync report needs: Bold for section headers
(bold alone is enough hierarchy against indented rows), MarkNote for the "here
is a consequence you could not have predicted" glyph, and StepPips for
rendering a position in a known pipeline.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1483** 👈
  * **PR #1485**
    * **PR #1484**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->