### PR TITLE
fix(pluck): apply parent changes as one batch

### DIFF
--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -181,17 +181,35 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Start the operation
 	handler.Start(basehandler.Reparent{Branch: source, OldParent: oldParentName, NewParent: onto})
 
-	// Step 1: Reparent children to grandparent
-	var reparentedChildren []string
+	// Steps 1 and 2 both change parents, and they are applied as a single
+	// batch. Reparenting the children and then moving the source passes
+	// through an intermediate shape where the grandparent holds both the
+	// source and its former children — a fork the linear-stack validator
+	// rejects even when the completed transformation is a valid chain.
+	moves := make([]engine.BranchParentMove, 0, len(children)+1)
+	for _, child := range children {
+		moves = append(moves, engine.BranchParentMove{Branch: child.GetName(), NewParent: grandparentBranch.GetName()})
+	}
+	moves = append(moves, engine.BranchParentMove{Branch: source, NewParent: onto})
+
 	if len(children) > 0 {
 		handler.OnStep(StepReparentingChild, basehandler.StatusStarted, "Reparenting children...")
+	} else {
+		handler.OnStep(StepReparentingChild, basehandler.StatusSkipped, "No children to reparent")
+	}
+	handler.OnStep(StepMovingSource, basehandler.StatusStarted, "Moving source branch...")
 
-		// All children move to the same grandparent, so reparent them in one
-		// batch instead of a per-child engine call.
-		if err := eng.ReparentBranches(gctx, children.Names(), grandparentBranch); err != nil {
+	if err := eng.ReparentBranchesToParents(gctx, moves); err != nil {
+		if len(children) > 0 {
 			handler.OnStep(StepReparentingChild, basehandler.StatusFailed, err.Error())
-			return fmt.Errorf("failed to reparent children to %s: %w", grandparentBranch.GetName(), err)
 		}
+		handler.OnStep(StepMovingSource, basehandler.StatusFailed, err.Error())
+		return fmt.Errorf("failed to set parent: %w", err)
+	}
+
+	// Step 1: children are now on the grandparent.
+	var reparentedChildren []string
+	if len(children) > 0 {
 		for _, child := range children {
 			handler.OnChildReparented(basehandler.Reparent{Branch: child.GetName(), OldParent: source, NewParent: grandparentBranch.GetName()})
 			reparentedChildren = append(reparentedChildren, child.GetName())
@@ -200,18 +218,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 				output.BranchName(source),
 				output.BranchName(grandparentBranch.GetName()))
 		}
-
 		handler.OnStep(StepReparentingChild, basehandler.StatusCompleted, "Children reparented")
-	} else {
-		handler.OnStep(StepReparentingChild, basehandler.StatusSkipped, "No children to reparent")
 	}
 
-	// Step 2: Move source to new parent
-	handler.OnStep(StepMovingSource, basehandler.StatusStarted, "Moving source branch...")
-	if err := eng.ReparentBranch(gctx, sourceBranch, ontoBranch); err != nil {
-		handler.OnStep(StepMovingSource, basehandler.StatusFailed, err.Error())
-		return fmt.Errorf("failed to set parent: %w", err)
-	}
+	// Step 2: the source is now on its new parent.
 	if eng.IsTrunk(ontoBranch) {
 		if _, err := eng.AssignBranchesToNewStack(gctx, sourceBranch, engine.BranchesOf(sourceBranch)); err != nil {
 			out.Warn("Failed to update stack ID for %s: %v", source, err)

--- a/internal/actions/pluck/pluck_test.go
+++ b/internal/actions/pluck/pluck_test.go
@@ -481,6 +481,40 @@ func TestPluckAction(t *testing.T) {
 		require.Equal(t, "untracked", parent1.GetName())
 	})
 
+	t.Run("plucks middle branch in a linear stack", func(t *testing.T) {
+		t.Parallel()
+		// main -> branch1 -> branch2 -> branch3
+		// Pluck branch2 to main
+		// Result: main -> {branch1, branch2} and branch1 -> branch3, which has
+		// no fork below a non-trunk branch even though reparenting branch3
+		// before moving branch2 briefly puts both under branch1.
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+				"branch3": "branch2",
+			})
+
+		// Rebuild the engine with linear stacks, as the CLI does for
+		// stack.shape=linear.
+		linearEngine, err := engine.NewEngine(engine.Options{
+			RepoRoot:     s.Scene.Dir,
+			Trunk:        "main",
+			LinearStacks: true,
+		})
+		require.NoError(t, err)
+		s.Engine = linearEngine
+		s.Context.Engine = linearEngine
+
+		require.NoError(t, Action(s.Context, Options{
+			Source: "branch2",
+			Onto:   "main",
+		}, nil))
+
+		require.Equal(t, "main", s.Engine.GetBranch("branch2").GetParent().GetName())
+		require.Equal(t, "branch1", s.Engine.GetBranch("branch3").GetParent().GetName())
+	})
+
 	t.Run("plucks from middle of stack correctly", func(t *testing.T) {
 		t.Parallel()
 		// main -> A -> B -> C -> D


### PR DESCRIPTION
Fixes #1657.

## Problem

`stackit pluck` rejected a valid middle-branch pluck under `stack.shape=linear`. The action reparented the source's children to the grandparent (`ReparentBranches`) and only afterwards moved the source itself (`ReparentBranch`). Each call validated the topology independently, so the linear validator saw the intermediate state — the grandparent holding both the source and its former children — and stopped the operation before any metadata changed:

```
failed to reparent children to branch1: linear stacks are enabled: branch1 would have multiple children (branch2, branch3)
```

The completed transformation is valid: for `main -> branch1 -> branch2 -> branch3`, plucking `branch2` onto `main` yields `main -> {branch1, branch2}` (a fork below trunk, which linear mode allows) and `branch1 -> branch3`.

## Fix

Both parent updates are built into a single `ReparentBranchesToParents` batch, so `validateLinearParentMoves` models the final graph rather than an arbitrary mutation order — the same approach `reorder` and `flatten` already use. Divergence points are still captured before any mutation, so the plucked branch keeps only its own commits.

Reparenting children before moving the source is preserved as the batch's application order, so stack-ID propagation is unchanged. The progress steps still report `StepReparentingChild` and `StepMovingSource` separately; because the mutation is now atomic, a failure marks both in-flight steps failed.

## Tests

Added `TestPluckAction/plucks middle branch in a linear stack`, which builds the engine with `LinearStacks: true` and runs the issue's reproduction. It fails on `main` with the exact error above and passes with this change.

Full `./internal/actions/...`, `./internal/engine/...`, `./internal/integration/...`, and `./internal/cli/...` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xHNbkzxCFJ5gV9TYkRL1p

---
_Generated by [Claude Code](https://claude.ai/code/session_018xHNbkzxCFJ5gV9TYkRL1p)_