### PR TITLE
fix(pluck): do not create undo snapshots for rejected cyclic moves

### DIFF
--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -60,25 +60,25 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	sourceBranch := eng.GetBranch(source)
 	ontoBranch := eng.GetBranch(onto)
 
+	// Cycle detection: ensure onto is not a descendant of source
+	if graph.IsDescendant(sourceBranch, ontoBranch) {
+		return fmt.Errorf("cannot pluck %s onto its own descendant %s", source, onto)
+	}
+
 	// Get source's direct children (they will be reparented to grandparent)
 	children := graph.ChildBranches(sourceBranch)
 	if err := actions.EnsureCanModifyHere(ctx, append(engine.BranchesOf(sourceBranch, ontoBranch), children...)...); err != nil {
 		return err
 	}
 
-	// Take snapshot before modifying the repository, but after the ownership
-	// guard, so a refusal leaves the undo stack untouched rather than evicting
-	// a real snapshot with a no-op entry.
+	// Take snapshot before modifying the repository, but after every check that
+	// can reject the pluck, so a refusal leaves the undo stack untouched rather
+	// than evicting a real recovery point with a no-op entry.
 	snapshotOpts := actions.NewSnapshot("pluck",
 		actions.WithFlagValue("--source", opts.Source),
 		actions.WithFlagValue("--onto", opts.Onto),
 	)
 	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
-
-	// Cycle detection: ensure onto is not a descendant of source
-	if graph.IsDescendant(sourceBranch, ontoBranch) {
-		return fmt.Errorf("cannot pluck %s onto its own descendant %s", source, onto)
-	}
 
 	// Get current parent (grandparent for children)
 	oldParent := sourceBranch.GetParent()

--- a/internal/actions/pluck/pluck_test.go
+++ b/internal/actions/pluck/pluck_test.go
@@ -279,6 +279,12 @@ func TestPluckAction(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot pluck")
 		require.Contains(t, err.Error(), "onto its own descendant")
+
+		// A rejected pluck must not leave an undo snapshot behind: no-op entries
+		// evict real recovery points once undo.max-depth is reached.
+		snapshots, err := s.Engine.GetSnapshots()
+		require.NoError(t, err)
+		require.Empty(t, snapshots, "rejected cyclic pluck should not record a snapshot")
 	})
 
 	t.Run("fails when source branch is not tracked", func(t *testing.T) {


### PR DESCRIPTION
Fixes #1658.

## Problem

`pluck.Action` called `actions.TakeBestEffortSnapshot` before its cycle-detection check, so a pluck rejected for targeting its own descendant still wrote a no-op entry to the undo stack. The comment above the snapshot claimed refusals leave undo history untouched, but that only held for the preceding ownership guard.

The real cost is not clutter: once `undo.max-depth` is reached, `enforceMaxStackDepth` deletes the oldest snapshot on every write, so each rejected cyclic pluck evicts a genuine recovery point.

## Change

Moved the `graph.IsDescendant` check up to sit with the other validation that can refuse the command without mutating anything — after the source/onto branches are resolved, before the ownership guard and the snapshot. The snapshot is now taken only once the pluck is known to proceed.

Behavior is otherwise unchanged: the same error message is returned, just earlier.

## Test

Extended the existing `prevents plucking onto descendant (cycle detection)` subtest to assert `GetSnapshots()` is empty after the rejection.

Verified the test is not vacuous — reverting only `pluck.go` fails it with exactly the issue's symptom:

```
Error: Should be empty, but was [{20260811033342.447_pluck pluck [--source branch1 --onto branch3] ...}]
Messages: rejected cyclic pluck should not record a snapshot
```

`go test ./internal/actions/pluck/` passes, `gofmt` and `go vet` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_014RGKdQ8ECxwwJyokBZGH1K)_