### PR TITLE
fix(pluck): fall back divergence point to grandparent revision

### DIFF
--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -114,9 +114,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	// Capture old divergence point for source branch
-	sourceOldParentRev, _ := eng.GetDivergencePoint(source)
-
 	// Build rebase specs for validation
 	// Order matters: children first (they depend on grandparent), then source
 	rebaseSpecs := make([]engine.RebaseSpec, 0, len(children)+1)
@@ -135,6 +132,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	sourceRev, err := eng.GetRevision(sourceBranch)
 	if err != nil {
 		return fmt.Errorf("failed to get revision for %s: %w", source, err)
+	}
+
+	// Capture old divergence point for source branch, falling back to the
+	// grandparent's revision (source's old parent) when unavailable.
+	sourceOldParentRev, divErr := eng.GetDivergencePoint(source)
+	if divErr != nil || sourceOldParentRev == "" {
+		sourceOldParentRev = grandparentRev
 	}
 
 	// Children: rebase onto grandparent (source's old parent)


### PR DESCRIPTION
## Summary

- `pluck.go` captured `sourceOldParentRev` via `eng.GetDivergencePoint(source)` and used it directly as the rebase `OldUpstream`, discarding the error and never checking for an empty result.
- If `GetDivergencePoint` fails (e.g. the recorded parent's revision can't be resolved from git), the rebase spec silently receives an empty `OldUpstream`, which surfaces later as a confusing rebase failure instead of a clear error.
- The child rebase specs a few lines below already fall back to a known revision (`sourceRev`) when their divergence point is unavailable, and `move.go` / `move/selection.go` apply the same fallback pattern for the source branch (falling back to the old parent's current revision downstream in `BuildRebaseSpecs`). `pluck.go` was the one remaining case missing this safety net.
- Fix: fall back to `grandparentRev` (source's old parent revision, already computed a few lines below for the rebase specs) when the divergence point is unavailable, mirroring the established pattern.

Checked for the same gap elsewhere in the codebase (`move.go:176`, `move/selection.go:42`) — both already handle the empty-string case downstream in `BuildRebaseSpecs`, so no other call site needed the same fix.

## Test plan

- [x] `go test ./internal/actions/pluck/...` — passes
- [x] `go test ./internal/actions/move/...` — passes (unaffected, verified no regression)
- [x] `go vet ./internal/actions/pluck/...` — clean
- [x] `gofmt -l` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1eGw63FGBeSwioGB4Vb5G)_