### PR TITLE
fix(git): handle HardReset failure when pulling checked-out branch

### DIFF
--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -103,7 +103,9 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		// NOTE: st sync checks for uncommitted changes before calling this,
 		// so hard reset is safe here.
 		if currentBranch == branchName {
-			_ = r.HardReset(ctx, "HEAD")
+			if err := r.HardReset(ctx, "HEAD"); err != nil {
+				return PullConflict, fmt.Errorf("updated %s but failed to reset current worktree: %w", branchName, err)
+			}
 		}
 
 		// If this branch is checked out in another clean worktree, reset it to


### PR DESCRIPTION
## Summary

- `UpdateBranchFromRemote` advances the branch ref to the remote fast-forward commit, then hard-resets the working tree/index to match. The error from that `HardReset` call was discarded (`_ = r.HardReset(...)`), so a failed reset left the ref pointing at the new commit while the working tree/index stayed stale — and the caller still received `PullDone` (success).
- Every other `HardReset` call site in the codebase (`internal/engine/pull.go`, `restack_impl.go`, `undo.go`) checks and wraps this error. This was the one outlier, and it sits right next to a sibling branch a few lines below in the same function that *does* check the equivalent `ResetWorktreeWorkingDir` error — making the omission look like an oversight.
- Now returns `PullConflict` with a wrapped error on failure, matching the established pattern from `internal/engine/pull.go`'s `ResetTrunkToRemote`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/git/...`
- [x] `go vet ./internal/git/...`, `gofmt -l` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01S7fp9y2hwiG4pz7KgifjVL)_