### PR TITLE
refactor(utils): deduplicate Run/RunWithWorkers worker pool

### DIFF
--- a/internal/utils/run_test.go
+++ b/internal/utils/run_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	items := []int{1, 2, 3, 4, 5}
+	var sum int64
+	var calls int64
+
+	Run(items, func(item int) {
+		atomic.AddInt64(&sum, int64(item))
+		atomic.AddInt64(&calls, 1)
+	})
+
+	if calls != int64(len(items)) {
+		t.Fatalf("calls = %d, want %d", calls, len(items))
+	}
+	if sum != 15 {
+		t.Fatalf("sum = %d, want 15", sum)
+	}
+}
+
+func TestRunEmpty(t *testing.T) {
+	t.Parallel()
+
+	Run([]int{}, func(int) {
+		t.Fatal("worker should not be called for empty input")
+	})
+}
+
+func TestRunWithWorkers(t *testing.T) {
+	t.Parallel()
+
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	var calls int64
+
+	RunWithWorkers(items, 3, func(int) {
+		atomic.AddInt64(&calls, 1)
+	})
+
+	if calls != int64(len(items)) {
+		t.Fatalf("calls = %d, want %d", calls, len(items))
+	}
+}
+
+func TestRunWithWorkersMoreWorkersThanItems(t *testing.T) {
+	t.Parallel()
+
+	items := []int{1, 2}
+	var calls int64
+
+	RunWithWorkers(items, 10, func(int) {
+		atomic.AddInt64(&calls, 1)
+	})
+
+	if calls != int64(len(items)) {
+		t.Fatalf("calls = %d, want %d", calls, len(items))
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -290,29 +290,7 @@ func IsDemoMode() bool {
 // Run runs the given worker function for each item in the slice in parallel.
 // It uses runtime.GOMAXPROCS(0) as the default number of workers.
 func Run[T any](items []T, worker func(item T)) {
-	if len(items) == 0 {
-		return
-	}
-
-	numWorkers := min(runtime.GOMAXPROCS(0), len(items))
-
-	jobs := make(chan T, len(items))
-	for _, item := range items {
-		jobs <- item
-	}
-	close(jobs)
-
-	var wg sync.WaitGroup
-	wg.Add(numWorkers)
-	for range numWorkers {
-		go func() {
-			defer wg.Done()
-			for item := range jobs {
-				worker(item)
-			}
-		}()
-	}
-	wg.Wait()
+	RunWithWorkers(items, 0, worker)
 }
 
 // ShortRevision returns a shortened version of a git revision hash.
@@ -349,7 +327,7 @@ func RunWithWorkers[T any](items []T, numWorkers int, worker func(item T)) {
 
 	var wg sync.WaitGroup
 	wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go func() {
 			defer wg.Done()
 			for item := range jobs {


### PR DESCRIPTION
## Summary
- `Run` reimplemented the exact same bounded worker pool as `RunWithWorkers`, just with slightly different (but equivalent) worker-count math, so the two copies had already drifted stylistically (`for range numWorkers` vs `for i := 0; i < numWorkers; i++`).
- Collapse `Run` into a one-line delegation to `RunWithWorkers` and modernize the surviving loop to `for range numWorkers`.
- These are among the most load-bearing concurrency primitives in the repo (used by `batchByBranch`, tree/annotation builders, submit, sync, etc. — see `.claude/rules/code-style.md`'s "Bound parallel fan-out" section), so having a single implementation is worth it.
- Neither function had any test coverage; added `internal/utils/run_test.go` covering both, including the empty-input and more-workers-than-items edge cases.

No behavior change — `Run(items, worker)` and `RunWithWorkers(items, 0, worker)` were already provably equivalent (both resolve to `min(GOMAXPROCS(0), len(items))` workers).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/utils/...`
- [x] `go test ./internal/utils/...` (including new `TestRun`, `TestRunEmpty`, `TestRunWithWorkers`, `TestRunWithWorkersMoreWorkersThanItems`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1uNgZTwYDTZ7cVGNEMvbr)_