### PR TITLE
refactor: dedupe short-SHA truncation via utils.ShortRevision

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // FormatRerereResolved renders the standard message describing how many
@@ -408,11 +409,7 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 		if rev == "" {
 			rev, _ = branch.GetRevision()
 		}
-		if len(rev) > 7 {
-			newRev = rev[:7]
-		} else {
-			newRev = rev
-		}
+		newRev = utils.ShortRevision(rev, 0)
 	}
 
 	// Report via callback if provided.
@@ -770,10 +767,7 @@ func PrintConflictStatus(ctx *app.Context, branchName string) error {
 	// Get rebase head
 	rebaseHead, err := reader.GetRebaseHead()
 	if err == nil && rebaseHead != "" {
-		rebaseHeadShort := rebaseHead
-		if len(rebaseHead) > 7 {
-			rebaseHeadShort = rebaseHead[:7]
-		}
+		rebaseHeadShort := utils.ShortRevision(rebaseHead, 0)
 		msg := output.Yellow(fmt.Sprintf("You are here (resolving %s):", rebaseHeadShort))
 		out.Info("%s", msg)
 		// Could show log here if needed

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // GetMergeMethod returns the merge method to use for PR merges.
@@ -294,10 +295,7 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 		switch pullResult {
 		case engine.PullDone:
 			rev, _ := trunk.GetRevision()
-			revShort := rev
-			if len(rev) > 7 {
-				revShort = rev[:7]
-			}
+			revShort := utils.ShortRevision(rev, 0)
 			out.Debug("Trunk fast-forwarded to %s", revShort)
 		case engine.PullUnneeded:
 			out.Debug("Trunk is up to date")

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // syncStackBranches pulls stack branches that are behind their remote counterparts.
@@ -167,10 +168,7 @@ func applyBranchSyncResult(branch engine.Branch, result engine.PullResult, err e
 		// Get the new revision (GetRevision reads live git, so it reflects the
 		// just-applied fast-forward without an engine rebuild).
 		rev, _ := branch.GetRevision()
-		revShort := rev
-		if len(rev) > 7 {
-			revShort = rev[:7]
-		}
+		revShort := utils.ShortRevision(rev, 0)
 		handler.EmitEvent(Event{
 			Phase:       PhaseBranches,
 			Type:        EventCompleted,

--- a/internal/actions/sync/trunk_sync.go
+++ b/internal/actions/sync/trunk_sync.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
@@ -50,10 +51,7 @@ func handleTrunkPullResult(ctx *app.Context, opts *Options, handler Handler, sum
 	case engine.PullDone:
 		trunk := nav.Trunk()
 		rev, _ := trunk.GetRevision()
-		revShort := rev
-		if len(rev) > 7 {
-			revShort = rev[:7]
-		}
+		revShort := utils.ShortRevision(rev, 0)
 		summary.TrunkUpdated = true
 		summary.TrunkRevision = revShort
 		handler.EmitEvent(Event{
@@ -85,10 +83,7 @@ func handleTrunkPullResult(ctx *app.Context, opts *Options, handler Handler, sum
 			ctx.Logger.Info("reset trunk to remote completed durationMs=%d", time.Since(resetStart).Milliseconds())
 			trunk := nav.Trunk()
 			rev, _ := trunk.GetRevision()
-			revShort := rev
-			if len(rev) > 7 {
-				revShort = rev[:7]
-			}
+			revShort := utils.ShortRevision(rev, 0)
 			summary.TrunkUpdated = true
 			summary.TrunkRevision = revShort
 			handler.EmitEvent(Event{


### PR DESCRIPTION
## Summary

- Six call sites across sync and merge action code each re-implemented the same "truncate a revision to 7 chars, else keep it whole" snippet inline instead of using the existing `utils.ShortRevision(rev, maxLen int) string` helper (`internal/utils/utils.go`), which is already used by 8 other call sites in the codebase (e.g. `internal/actions/merge/plan.go`, `internal/cli/navigation/log.go`, `internal/cli/stack/sync.go`).
- Replaced the duplicated `if len(rev) > 7 { ... } else { ... }` blocks with `utils.ShortRevision(rev, 0)` in:
  - `internal/actions/sync/branch_sync.go`
  - `internal/actions/sync/trunk_sync.go` (2 call sites)
  - `internal/actions/common.go` (2 call sites: `reportRestackResult`, `PrintConflictStatus`)
  - `internal/actions/merge/execute.go`
- No behavior change — each replacement is semantically identical to the code it replaces.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/...`
- [x] `gofmt -l` on all edited files (clean)
- [x] `go test ./internal/actions/...` (all packages pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ziu4KEFvFojP33xKDMqzj)_