### PR TITLE
fix(dashboard): use analyzer-computed PR title, dedupe short-SHA truncation

### DIFF
--- a/internal/actions/tree.go
+++ b/internal/actions/tree.go
@@ -277,8 +277,8 @@ func buildTreeAnnotation(
 		// The short style does not batch stats, so resolve the SHA directly.
 		if stat.ShortSHA != "" {
 			annotation.LocalSHA = stat.ShortSHA
-		} else if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
-			annotation.LocalSHA = sha[:7]
+		} else if sha, err := branch.GetRevision(); err == nil {
+			annotation.LocalSHA = utils.ShortRevision(sha, 0)
 		}
 	}
 	return annotation

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -398,14 +398,10 @@ func (m *shippableModel) rebuildCache() {
 	for _, stack := range m.stacks {
 		rootBranch := stack.RootBranch()
 
-		// Compute display title from commit subject (this calls git log)
-		title := rootBranch // Default fallback
-		if branch := m.engine.GetBranch(rootBranch); branch.GetName() != "" {
-			if prTitle := branch.DefaultPRTitle(); prTitle != "" {
-				title = prTitle
-			}
-		}
-		m.cache.stackTitles[rootBranch] = title
+		// Use the title the analyzer already computed (PR title > commit subject > branch name)
+		// rather than recomputing from commit subject alone, which both discards a real PR
+		// title when one exists and re-spawns git to redo work the analyzer already did.
+		m.cache.stackTitles[rootBranch] = stack.DisplayTitle()
 
 		// Get stack description from metadata
 		if branch := m.engine.GetBranch(rootBranch); branch.GetName() != "" {

--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -144,9 +144,7 @@ func (e *engineImpl) BatchChangedFileCounts(ctx context.Context, branches Branch
 func (e *engineImpl) BatchBranchStats(branches Branches) map[string]BranchStat {
 	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) BranchStat {
 		st := BranchStat{}
-		if len(head) >= 7 {
-			st.ShortSHA = head[:7]
-		}
+		st.ShortSHA = utils.ShortRevision(head, 0)
 		if e.IsTrunk(b) {
 			return st
 		}


### PR DESCRIPTION
## Summary
- The dashboard stack list recomputed its display title from the root branch's commit subject alone, discarding the real GitHub PR title even though the analyzer had already fetched it (`Stack.PRTitle`, with fallback chain PR title > commit subject > branch name via `Stack.DisplayTitle()`). This also re-spawned `git log` per stack on every refresh/auto-refresh tick to redo work the analyzer already did.
- Fixes `rebuildCache` in `internal/cli/dashboard/shippable_model.go` to use `stack.DisplayTitle()` instead.
- Drive-by: folds the two remaining inline `sha[:7]` truncations (`internal/actions/tree.go`, `internal/engine/branch_view.go`) into `utils.ShortRevision`, completing the consolidation started in bae6300.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/... ./internal/actions/... ./internal/shippable/... ./internal/cli/dashboard/...`
- [x] `gofmt -l` on changed files (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr4KKhwCxByMqUZxfYbpp6)_