### PR TITLE
Merging 4 PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,11 +436,11 @@ By default, `get` **freezes** the fetched branches locally. This prevents accide
 
 ### Native GitHub Stack Sync (Experimental)
 
-GitHub's native stacked PR UI requires a linear PR chain. To reconcile its Stack API metadata automatically during normal submission, enable the submit option once:
+GitHub's native stacked PR UI requires a linear PR chain. To reconcile its server-side Stack metadata automatically during normal submission, enable the option once:
 
 ```bash
 stackit config set stack.shape linear
-stackit config set submit.githubStack true
+stackit config set github.stack true
 stackit submit
 ```
 

--- a/README.md
+++ b/README.md
@@ -436,14 +436,15 @@ By default, `get` **freezes** the fetched branches locally. This prevents accide
 
 ### Native GitHub Stack Sync (Experimental)
 
-GitHub's native stacked PR UI requires a linear PR chain. To reconcile its Stack API metadata during submission, opt into linear topology and use the native-stack flag:
+GitHub's native stacked PR UI requires a linear PR chain. To reconcile its Stack API metadata automatically during normal submission, enable the submit option once:
 
 ```bash
 stackit config set stack.shape linear
-stackit submit --with-native-stack
+stackit config set submit.githubStack true
+stackit submit
 ```
 
-This experimental option only syncs GitHub's server-side Stack resource; it does not change Stackit metadata or normal `stackit submit` behavior without the flag.
+With this option enabled, submissions containing two or more PRs reconcile GitHub's server-side Stack resource. Single-PR submissions behave normally. Use `stackit submit --with-native-stack` for a one-off sync instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,17 @@ stackit get 123
 ```
 By default, `get` **freezes** the fetched branches locally. This prevents accidental local modifications while you build on top of them, without affecting the original author's metadata. Use `stackit unfreeze` if you need to modify them.
 
+### Native GitHub Stack Sync (Experimental)
+
+GitHub's native stacked PR UI requires a linear PR chain. To reconcile its Stack API metadata during submission, opt into linear topology and use the native-stack flag:
+
+```bash
+stackit config set stack.shape linear
+stackit submit --with-native-stack
+```
+
+This experimental option only syncs GitHub's server-side Stack resource; it does not change Stackit metadata or normal `stackit submit` behavior without the flag.
+
 ---
 
 ## Frozen & Locked Branches

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,7 @@ git config --local --add stackit.trunks develop
 | `stackit.stack.shape` | string | `tree` | Stack topology (`tree` or `linear`; linear prevents forks below non-trunk branches) |
 | `stackit.submit.footer` | bool | `true` | Include PR footer in descriptions |
 | `stackit.submit.draft` | bool | `false` | Create PRs as drafts by default |
+| `stackit.submit.githubStack` | bool | `false` | Sync native GitHub Stack metadata for eligible linear PR chains |
 | `stackit.submit.web` | string | `never` | When to open PRs in browser (always/created/never) |
 | `stackit.submit.labels` | string[] | `[]` | Default labels for PRs |
 | `stackit.submit.reviewers` | string[] | `[]` | Default reviewers for PRs |
@@ -231,6 +232,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `stack.shape` | string | `tree` | Stack topology (`tree` or `linear`; linear prevents forks below non-trunk branches) | Yes |
 | `submit.footer` | bool | `true` | Include PR footer | Yes |
 | `submit.draft` | bool | `false` | Create PRs as drafts by default | Yes |
+| `submit.githubStack` | bool | `false` | Sync native GitHub Stack metadata for eligible linear PR chains | Yes |
 | `submit.web` | string | `never` | Open PRs in browser (always/created/never) | Yes |
 | `submit.labels` | string[] | `[]` | Default labels for PRs | Yes (additive) |
 | `submit.reviewers` | string[] | `[]` | Default reviewers for PRs | Yes (additive) |

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,7 +58,7 @@ git config --local --add stackit.trunks develop
 | `stackit.stack.shape` | string | `tree` | Stack topology (`tree` or `linear`; linear prevents forks below non-trunk branches) |
 | `stackit.submit.footer` | bool | `true` | Include PR footer in descriptions |
 | `stackit.submit.draft` | bool | `false` | Create PRs as drafts by default |
-| `stackit.submit.githubStack` | bool | `false` | Sync native GitHub Stack metadata for eligible linear PR chains |
+| `stackit.github.stack` | bool | `false` | Sync native Stack metadata for eligible linear PR chains |
 | `stackit.submit.web` | string | `never` | When to open PRs in browser (always/created/never) |
 | `stackit.submit.labels` | string[] | `[]` | Default labels for PRs |
 | `stackit.submit.reviewers` | string[] | `[]` | Default reviewers for PRs |
@@ -191,6 +191,10 @@ submit:
   assignees:    # Default assignees for PRs
     - octocat
 
+# GitHub integration settings
+github:
+  stack: true  # Sync native Stack metadata for eligible linear PR chains
+
 # Merge method preference
 merge:
   method: squash  # squash, merge, or rebase
@@ -232,7 +236,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `stack.shape` | string | `tree` | Stack topology (`tree` or `linear`; linear prevents forks below non-trunk branches) | Yes |
 | `submit.footer` | bool | `true` | Include PR footer | Yes |
 | `submit.draft` | bool | `false` | Create PRs as drafts by default | Yes |
-| `submit.githubStack` | bool | `false` | Sync native GitHub Stack metadata for eligible linear PR chains | Yes |
+| `github.stack` | bool | `false` | Sync native Stack metadata for eligible linear PR chains | Yes |
 | `submit.web` | string | `never` | Open PRs in browser (always/created/never) | Yes |
 | `submit.labels` | string[] | `[]` | Default labels for PRs | Yes (additive) |
 | `submit.reviewers` | string[] | `[]` | Default reviewers for PRs | Yes (additive) |
@@ -285,6 +289,7 @@ type ProjectConfig struct {
     Trunks         []string         `yaml:"trunks,omitempty"`
     Branch         BranchConfig     `yaml:"branch,omitempty"`
     Submit         SubmitConfig     `yaml:"submit,omitempty"`
+    GitHub         GitHubConfig     `yaml:"github,omitempty"`
     Merge          MergeConfig      `yaml:"merge,omitempty"`
     CI             CIConfig         `yaml:"ci,omitempty"`
     Undo           UndoConfig       `yaml:"undo,omitempty"`

--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -31,7 +31,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	// Get submit.footer
 	submitFooter := cfg.SubmitFooter()
-	submitGitHubStack := cfg.SubmitGitHubStack()
+	githubStack := cfg.GitHubStack()
 
 	// Get merge.method
 	mergeMethod := cfg.MergeMethod()
@@ -57,7 +57,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("branch.pattern"), branchPattern))
 	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("submit.footer"), submitFooter))
-	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("submit.githubStack"), submitGitHubStack))
+	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("github.stack"), githubStack))
 	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("merge.method"), mergeMethod))
 
 	// CI settings

--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -31,6 +31,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	// Get submit.footer
 	submitFooter := cfg.SubmitFooter()
+	submitGitHubStack := cfg.SubmitGitHubStack()
 
 	// Get merge.method
 	mergeMethod := cfg.MergeMethod()
@@ -56,6 +57,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("branch.pattern"), branchPattern))
 	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("submit.footer"), submitFooter))
+	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("submit.githubStack"), submitGitHubStack))
 	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("merge.method"), mergeMethod))
 
 	// CI settings

--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // Event represents a feedback event from the submit action.
@@ -95,14 +96,15 @@ type BranchProgressEvent struct {
 
 func (BranchProgressEvent) submitEvent() {}
 
-// GitHubStackCreatedEvent reports that submit created GitHub's native Stack
+// GitHubStackSyncedEvent reports that submit reconciled GitHub's native Stack
 // metadata after every PR in the selected chain was submitted.
-type GitHubStackCreatedEvent struct {
+type GitHubStackSyncedEvent struct {
 	Number       int
 	PullRequests []int
+	Action       github.StackSyncAction
 }
 
-func (GitHubStackCreatedEvent) submitEvent() {}
+func (GitHubStackSyncedEvent) submitEvent() {}
 
 // CompletionOutcome classifies how a submit run ended, so handlers can decide
 // presentation without string-matching messages.

--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -95,6 +95,15 @@ type BranchProgressEvent struct {
 
 func (BranchProgressEvent) submitEvent() {}
 
+// GitHubStackCreatedEvent reports that submit created GitHub's native Stack
+// metadata after every PR in the selected chain was submitted.
+type GitHubStackCreatedEvent struct {
+	Number       int
+	PullRequests []int
+}
+
+func (GitHubStackCreatedEvent) submitEvent() {}
+
 // CompletionOutcome classifies how a submit run ended, so handlers can decide
 // presentation without string-matching messages.
 type CompletionOutcome string

--- a/internal/actions/submit/json_handler.go
+++ b/internal/actions/submit/json_handler.go
@@ -16,10 +16,11 @@ type JSONResult struct {
 	GitHubStack *JSONGitHubStackResult `json:"github_stack,omitempty"`
 }
 
-// JSONGitHubStackResult identifies native GitHub Stack metadata created by submit.
+// JSONGitHubStackResult identifies native GitHub Stack metadata reconciled by submit.
 type JSONGitHubStackResult struct {
-	Number       int   `json:"number"`
-	PullRequests []int `json:"pull_requests"`
+	Number       int    `json:"number"`
+	PullRequests []int  `json:"pull_requests"`
+	Action       string `json:"action"`
 }
 
 // JSONBranchResult is one branch's plan and result in submit JSON output.
@@ -97,8 +98,8 @@ func (h *JSONHandler) OnEvent(e Event) {
 		b := h.branch(ev.BranchName)
 		b.Warnings = append(b.Warnings, ev.Warning)
 
-	case GitHubStackCreatedEvent:
-		h.Result.GitHubStack = &JSONGitHubStackResult{Number: ev.Number, PullRequests: ev.PullRequests}
+	case GitHubStackSyncedEvent:
+		h.Result.GitHubStack = &JSONGitHubStackResult{Number: ev.Number, PullRequests: ev.PullRequests, Action: string(ev.Action)}
 
 	case CompletionEvent:
 		h.Result.Outcome = ev.Outcome

--- a/internal/actions/submit/json_handler.go
+++ b/internal/actions/submit/json_handler.go
@@ -9,10 +9,17 @@ import (
 
 // JSONResult is the machine-readable summary of a submit run.
 type JSONResult struct {
-	Outcome  CompletionOutcome  `json:"outcome"`
-	Message  string             `json:"message,omitempty"`
-	Error    string             `json:"error,omitempty"`
-	Branches []JSONBranchResult `json:"branches"`
+	Outcome     CompletionOutcome      `json:"outcome"`
+	Message     string                 `json:"message,omitempty"`
+	Error       string                 `json:"error,omitempty"`
+	Branches    []JSONBranchResult     `json:"branches"`
+	GitHubStack *JSONGitHubStackResult `json:"github_stack,omitempty"`
+}
+
+// JSONGitHubStackResult identifies native GitHub Stack metadata created by submit.
+type JSONGitHubStackResult struct {
+	Number       int   `json:"number"`
+	PullRequests []int `json:"pull_requests"`
 }
 
 // JSONBranchResult is one branch's plan and result in submit JSON output.
@@ -89,6 +96,9 @@ func (h *JSONHandler) OnEvent(e Event) {
 	case BranchWarningEvent:
 		b := h.branch(ev.BranchName)
 		b.Warnings = append(b.Warnings, ev.Warning)
+
+	case GitHubStackCreatedEvent:
+		h.Result.GitHubStack = &JSONGitHubStackResult{Number: ev.Number, PullRequests: ev.PullRequests}
 
 	case CompletionEvent:
 		h.Result.Outcome = ev.Outcome

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -161,7 +161,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// after validation. The explicit flag remains strict.
 	explicitGitHubStack := opts.CreateGitHubStack
 	configuredGitHubStack := opts.ConfigGitHubStack
-	if ctx.Config != nil && ctx.Config.SubmitGitHubStack() {
+	if ctx.Config != nil && ctx.Config.GitHubStack() {
 		configuredGitHubStack = true
 	}
 	if !explicitGitHubStack && configuredGitHubStack {

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
@@ -46,6 +47,7 @@ type Options struct {
 	SubmitFooter         bool // Whether to include PR footer (from config)
 	NoLabels             bool // Skip applying default labels from config
 	NoAssignees          bool // Skip applying default assignees from config
+	CreateGitHubStack    bool // Create native GitHub Stack metadata after submitting PRs
 
 	// Config-driven options (these are merged with flags)
 	ConfigDraft     bool     // Default draft mode from config
@@ -73,6 +75,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Validate flags
 	if opts.Draft && opts.Publish {
 		return fmt.Errorf("can't use both --publish and --draft flags in one command")
+	}
+	if opts.CreateGitHubStack && (ctx.Config == nil || ctx.Config.StackShape() != config.StackShapeLinear) {
+		return fmt.Errorf("native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
 	}
 
 	nav := ctx.Navigator()
@@ -155,7 +160,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	for i, branchName := range branches {
 		branchObjs[i] = nav.GetBranch(branchName)
 	}
-
 	// Resolve up-to-date status for every branch in one batched parent-revision
 	// read rather than a per-branch IsBranchUpToDate() (each of which shells a
 	// separate `git rev-parse` for the parent).
@@ -237,6 +241,17 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			branchObjs[i] = nav.GetBranch(branchName)
 		}
 	}
+	// Validate native Stack requirements against the final branch list. Submit
+	// validation can prune stale descendants, so validating earlier could let a
+	// one-PR list perform normal PR writes before native Stack creation fails.
+	if opts.CreateGitHubStack {
+		if err := validateGitHubStackChain(eng, branchObjs); err != nil {
+			return err
+		}
+		if len(branchObjs) < 2 {
+			return fmt.Errorf("a GitHub Stack requires at least two pull requests")
+		}
+	}
 
 	var remoteStatuses engine.BranchRemoteStatuses
 	if remoteStatusCh != nil {
@@ -261,6 +276,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	if len(submissionInfos) == 0 {
+		if opts.CreateGitHubStack {
+			if err := publishGitHubStackMetadata(ctx, branchObjs, handler); err != nil {
+				handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+				return fmt.Errorf("PRs are already up to date, but creating native GitHub Stack metadata failed: %w", err)
+			}
+			handler.OnEvent(CompletionEvent{Outcome: OutcomeComplete, Message: "GitHub Stack metadata submitted", Duration: time.Since(start)})
+			return nil
+		}
 		handler.OnEvent(CompletionEvent{Outcome: OutcomeUpToDate, Message: "All PRs up to date"})
 		return nil
 	}
@@ -389,10 +412,70 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to push metadata to remote: %w. Your PRs were created/updated successfully, but metadata sync failed. Run 'st sync' and try submitting again", err)
 	}
 
+	if opts.CreateGitHubStack {
+		if err := publishGitHubStackMetadata(ctx, branchObjs, handler); err != nil {
+			handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+			return fmt.Errorf("PRs were submitted successfully, but creating native GitHub Stack metadata failed: %w", err)
+		}
+	}
+
 	ctx.Logger.Info("submit completed branchCount=%v", len(branches))
 
 	handler.OnEvent(CompletionEvent{Outcome: OutcomeComplete, Message: "Submit complete", Duration: time.Since(start)})
 	return nil
+}
+
+func publishGitHubStackMetadata(ctx *app.Context, branches engine.Branches, handler Handler) error {
+	stack, pullRequests, err := createGitHubStackMetadata(ctx, branches)
+	if err != nil {
+		return err
+	}
+	handler.OnEvent(GitHubStackCreatedEvent{Number: stack.Number, PullRequests: pullRequests})
+	return nil
+}
+
+func validateGitHubStackChain(eng engine.Engine, branches engine.Branches) error {
+	graph := eng.Graph(engine.SortStrategyAlphabetical)
+	for _, branch := range branches {
+		if children := graph.Children(branch); len(children) > 1 {
+			return fmt.Errorf("branch %q forks to %s; native GitHub Stacks require a linear chain", branch.GetName(), strings.Join(children, ", "))
+		}
+	}
+	return nil
+}
+
+// createGitHubStackMetadata creates GitHub's native Stack resource after the
+// normal submit flow has created or updated every PR in the selected chain.
+func createGitHubStackMetadata(ctx *app.Context, branches engine.Branches) (*github.StackInfo, []int, error) {
+	if len(branches) < 2 {
+		return nil, nil, fmt.Errorf("a GitHub Stack requires at least two pull requests")
+	}
+
+	pullRequests := make([]int, 0, len(branches))
+	for _, branch := range branches {
+		pr, err := branch.GetPrInfo()
+		if err != nil || pr == nil || pr.Number() == nil {
+			return nil, nil, fmt.Errorf("branch %q has no submitted pull request", branch.GetName())
+		}
+		pullRequests = append(pullRequests, *pr.Number())
+	}
+
+	client, err := getGitHubClient(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	stackClient, ok := client.(github.StackClient)
+	if !ok {
+		return nil, nil, fmt.Errorf("GitHub Stack API is unavailable for this client")
+	}
+
+	remoteCtx, cancel := ctx.RemoteOperationContext()
+	defer cancel()
+	stack, err := stackClient.CreateStack(remoteCtx, pullRequests)
+	if err != nil {
+		return nil, nil, err
+	}
+	return stack, pullRequests, nil
 }
 
 // buildStackSnapshot captures the stack relationships and metadata that submit

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -248,8 +248,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if err := validateGitHubStackChain(eng, branchObjs); err != nil {
 			return err
 		}
-		if len(branchObjs) < 2 {
-			return fmt.Errorf("a GitHub Stack requires at least two pull requests")
+		if err := github.ValidateStackPullRequestCount(len(branchObjs)); err != nil {
+			return err
 		}
 	}
 
@@ -426,11 +426,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 }
 
 func publishGitHubStackMetadata(ctx *app.Context, branches engine.Branches, handler Handler) error {
-	stack, pullRequests, err := createGitHubStackMetadata(ctx, branches)
+	stack, pullRequests, action, err := createGitHubStackMetadata(ctx, branches)
 	if err != nil {
 		return err
 	}
-	handler.OnEvent(GitHubStackCreatedEvent{Number: stack.Number, PullRequests: pullRequests})
+	handler.OnEvent(GitHubStackSyncedEvent{Number: stack.Number, PullRequests: pullRequests, Action: action})
 	return nil
 }
 
@@ -444,38 +444,38 @@ func validateGitHubStackChain(eng engine.Engine, branches engine.Branches) error
 	return nil
 }
 
-// createGitHubStackMetadata creates GitHub's native Stack resource after the
+// createGitHubStackMetadata reconciles GitHub's native Stack resource after the
 // normal submit flow has created or updated every PR in the selected chain.
-func createGitHubStackMetadata(ctx *app.Context, branches engine.Branches) (*github.StackInfo, []int, error) {
-	if len(branches) < 2 {
-		return nil, nil, fmt.Errorf("a GitHub Stack requires at least two pull requests")
+func createGitHubStackMetadata(ctx *app.Context, branches engine.Branches) (*github.StackInfo, []int, github.StackSyncAction, error) {
+	if err := github.ValidateStackPullRequestCount(len(branches)); err != nil {
+		return nil, nil, "", err
 	}
 
 	pullRequests := make([]int, 0, len(branches))
 	for _, branch := range branches {
 		pr, err := branch.GetPrInfo()
 		if err != nil || pr == nil || pr.Number() == nil {
-			return nil, nil, fmt.Errorf("branch %q has no submitted pull request", branch.GetName())
+			return nil, nil, "", fmt.Errorf("branch %q has no submitted pull request", branch.GetName())
 		}
 		pullRequests = append(pullRequests, *pr.Number())
 	}
 
 	client, err := getGitHubClient(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	stackClient, ok := client.(github.StackClient)
 	if !ok {
-		return nil, nil, fmt.Errorf("GitHub Stack API is unavailable for this client")
+		return nil, nil, "", fmt.Errorf("GitHub Stack API is unavailable for this client")
 	}
 
 	remoteCtx, cancel := ctx.RemoteOperationContext()
 	defer cancel()
-	stack, err := stackClient.CreateStack(remoteCtx, pullRequests)
+	stack, action, err := github.EnsureStack(remoteCtx, stackClient, pullRequests)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
-	return stack, pullRequests, nil
+	return stack, pullRequests, action, nil
 }
 
 // buildStackSnapshot captures the stack relationships and metadata that submit

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -50,11 +50,12 @@ type Options struct {
 	CreateGitHubStack    bool // Create native GitHub Stack metadata after submitting PRs
 
 	// Config-driven options (these are merged with flags)
-	ConfigDraft     bool     // Default draft mode from config
-	ConfigWeb       string   // When to open browser from config (always/created/never)
-	ConfigLabels    []string // Default labels from config
-	ConfigReviewers []string // Default reviewers from config
-	ConfigAssignees []string // Default assignees from config
+	ConfigDraft       bool     // Default draft mode from config
+	ConfigGitHubStack bool     // Sync native GitHub Stack metadata for eligible submits
+	ConfigWeb         string   // When to open browser from config (always/created/never)
+	ConfigLabels      []string // Default labels from config
+	ConfigReviewers   []string // Default reviewers from config
+	ConfigAssignees   []string // Default assignees from config
 }
 
 // Info contains information about a branch to submit
@@ -76,10 +77,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if opts.Draft && opts.Publish {
 		return fmt.Errorf("can't use both --publish and --draft flags in one command")
 	}
-	if opts.CreateGitHubStack && (ctx.Config == nil || ctx.Config.StackShape() != config.StackShapeLinear) {
-		return fmt.Errorf("native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
-	}
-
 	nav := ctx.Navigator()
 	eng := ctx.Engine
 
@@ -159,6 +156,16 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	branchObjs := make(engine.Branches, len(branches))
 	for i, branchName := range branches {
 		branchObjs[i] = nav.GetBranch(branchName)
+	}
+	// Configured Stack sync is assessed against the final submitted branch list
+	// after validation. The explicit flag remains strict.
+	explicitGitHubStack := opts.CreateGitHubStack
+	configuredGitHubStack := opts.ConfigGitHubStack
+	if ctx.Config != nil && ctx.Config.SubmitGitHubStack() {
+		configuredGitHubStack = true
+	}
+	if !explicitGitHubStack && configuredGitHubStack {
+		opts.CreateGitHubStack = true
 	}
 	// Resolve up-to-date status for every branch in one batched parent-revision
 	// read rather than a per-branch IsBranchUpToDate() (each of which shells a
@@ -245,11 +252,18 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// validation can prune stale descendants, so validating earlier could let a
 	// one-PR list perform normal PR writes before native Stack creation fails.
 	if opts.CreateGitHubStack {
-		if err := validateGitHubStackChain(eng, branchObjs); err != nil {
-			return err
-		}
-		if err := github.ValidateStackPullRequestCount(len(branchObjs)); err != nil {
-			return err
+		if !explicitGitHubStack && (len(branchObjs) < github.MinStackPullRequests || len(branchObjs) > github.MaxStackPullRequests) {
+			opts.CreateGitHubStack = false
+		} else {
+			if ctx.Config == nil || ctx.Config.StackShape() != config.StackShapeLinear {
+				return fmt.Errorf("native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
+			}
+			if err := validateGitHubStackChain(eng, branchObjs); err != nil {
+				return err
+			}
+			if err := github.ValidateStackPullRequestCount(len(branchObjs)); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -378,7 +378,7 @@ func TestSubmitCreatesNativeGitHubStackWhenConfigured(t *testing.T) {
 	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
 	require.NoError(t, err)
 	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
-	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	require.NoError(t, cfg.SetGitHubStack(true))
 	s.Context.Config = cfg
 
 	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{})
@@ -401,7 +401,7 @@ func TestSubmitConfiguredGitHubStackFallsBackWhenValidationPrunesToOnePullReques
 	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
 	require.NoError(t, err)
 	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
-	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	require.NoError(t, cfg.SetGitHubStack(true))
 	s.Context.Config = cfg
 
 	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{})
@@ -418,10 +418,10 @@ func TestSubmitConfiguredGitHubStackSkipsSinglePullRequest(t *testing.T) {
 
 	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
 	require.NoError(t, err)
-	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	require.NoError(t, cfg.SetGitHubStack(true))
 	s.Context.Config = cfg
 
-	err = submit.Action(s.Context, submit.Options{DryRun: true, ConfigGitHubStack: cfg.SubmitGitHubStack()}, &noopHandler{})
+	err = submit.Action(s.Context, submit.Options{DryRun: true, ConfigGitHubStack: cfg.GitHubStack()}, &noopHandler{})
 	require.NoError(t, err)
 }
 
@@ -440,7 +440,7 @@ func TestSubmitConfiguredGitHubStackSkipsOversizedSubmission(t *testing.T) {
 	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
 	require.NoError(t, err)
 	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
-	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	require.NoError(t, cfg.SetGitHubStack(true))
 	s.Context.Config = cfg
 
 	err = submit.Action(s.Context, submit.Options{DryRun: true}, &noopHandler{})

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -364,6 +364,89 @@ func TestSubmitCreatesNativeGitHubStackWhenRequested(t *testing.T) {
 	require.Len(t, mockConfig.CreatedStacks, 1)
 }
 
+func TestSubmitCreatesNativeGitHubStackWhenConfigured(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedStacks, 1)
+}
+
+func TestSubmitConfiguredGitHubStackFallsBackWhenValidationPrunesToOnePullRequest(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	s.Checkout("base").Commit("advance base").Checkout("api")
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedPRs, 1, "the valid parent should submit normally")
+	require.Empty(t, mockConfig.CreatedStacks, "one surviving PR must not create native Stack metadata")
+}
+
+func TestSubmitConfiguredGitHubStackSkipsSinglePullRequest(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"feature": "main"})
+	s.Checkout("feature")
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{DryRun: true, ConfigGitHubStack: cfg.SubmitGitHubStack()}, &noopHandler{})
+	require.NoError(t, err)
+}
+
+func TestSubmitConfiguredGitHubStackSkipsOversizedSubmission(t *testing.T) {
+	t.Parallel()
+	branches := make(map[string]string, github.MaxStackPullRequests+1)
+	parent := "main"
+	for i := range github.MaxStackPullRequests + 1 {
+		branch := fmt.Sprintf("branch-%03d", i)
+		branches[branch] = parent
+		parent = branch
+	}
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithStack(branches)
+	s.Checkout(parent)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	require.NoError(t, cfg.SetSubmitGitHubStack(true))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{DryRun: true}, &noopHandler{})
+	require.NoError(t, err, "an oversized submission is ineligible for native Stack sync but should still submit normally")
+}
+
 func TestSubmitGitHubStackRejectsMoreThanOneHundredBranchesBeforeSubmit(t *testing.T) {
 	t.Parallel()
 	branches := make(map[string]string, github.MaxStackPullRequests+1)

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -3,6 +3,7 @@ package submit_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	stackitconfig "github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
@@ -354,6 +356,33 @@ func TestSubmitCreatesNativeGitHubStackWhenRequested(t *testing.T) {
 	apiPR, err := s.Engine.GetBranch("api").GetPrInfo()
 	require.NoError(t, err)
 	require.Equal(t, []int{*basePR.Number(), *apiPR.Number()}, mockConfig.CreatedStacks[0])
+
+	// A repeated submit must leave the existing native Stack intact rather than
+	// trying to create a second resource for the same pull requests.
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedStacks, 1)
+}
+
+func TestSubmitGitHubStackRejectsMoreThanOneHundredBranchesBeforeSubmit(t *testing.T) {
+	t.Parallel()
+	branches := make(map[string]string, github.MaxStackPullRequests+1)
+	parent := "main"
+	for i := range github.MaxStackPullRequests + 1 {
+		branch := fmt.Sprintf("branch-%03d", i)
+		branches[branch] = parent
+		parent = branch
+	}
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithStack(branches)
+	s.Checkout(parent)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{CreateGitHubStack: true}, &noopHandler{})
+	require.EqualError(t, err, "a GitHub Stack supports at most 100 pull requests (got 101)")
 }
 
 func TestSubmitNativeGitHubStackRejectsPrunedSinglePullRequestBeforeSubmit(t *testing.T) {

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/submit"
 	"github.com/getstackit/stackit/internal/app"
+	stackitconfig "github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
@@ -326,6 +327,78 @@ func TestActionWithMockedGitHub(t *testing.T) {
 		err = submit.Action(s.Context, opts, &noopHandler{})
 		require.NoError(t, err, "submit should succeed when branch is already in sync with remote")
 	})
+}
+
+func TestSubmitCreatesNativeGitHubStackWhenRequested(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedStacks, 1)
+
+	basePR, err := s.Engine.GetBranch("base").GetPrInfo()
+	require.NoError(t, err)
+	apiPR, err := s.Engine.GetBranch("api").GetPrInfo()
+	require.NoError(t, err)
+	require.Equal(t, []int{*basePR.Number(), *apiPR.Number()}, mockConfig.CreatedStacks[0])
+}
+
+func TestSubmitNativeGitHubStackRejectsPrunedSinglePullRequestBeforeSubmit(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	// Advance the parent after its child was created so submit validation prunes
+	// the child for needing a restack.
+	s.Checkout("base").Commit("advance base").Checkout("api")
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, CreateGitHubStack: true}, &noopHandler{})
+	require.EqualError(t, err, "a GitHub Stack requires at least two pull requests")
+	require.Empty(t, mockConfig.CreatedPRs, "native Stack validation must fail before submitting the surviving parent")
+}
+
+func TestSubmitGitHubStackRequiresLinearMode(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+
+	err := submit.Action(s.Context, submit.Options{CreateGitHubStack: true}, &noopHandler{})
+	require.EqualError(t, err, "native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
+}
+
+func TestSubmitGitHubStackRejectsForkedChain(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base", "ui": "base"})
+	s.Checkout("base")
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{StackRange: engine.StackRangeFull(), CreateGitHubStack: true}, &noopHandler{})
+	require.EqualError(t, err, "branch \"base\" forks to api, ui; native GitHub Stacks require a linear chain")
 }
 
 func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/api/registry"
 	"github.com/getstackit/stackit/internal/api/reqid"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
 )
@@ -77,6 +78,12 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 	ctx.Context = r.Context()
 	ctx.GitHubClient = entry.GitHub
+	cfg, err := config.LoadConfig(entry.RepoRoot)
+	if err != nil {
+		http.Error(w, "failed to load repository configuration", http.StatusInternalServerError)
+		return
+	}
+	ctx.Config = cfg
 
 	opts := submit.Options{
 		Branch:     rootBranch,

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -31,7 +31,7 @@ const (
 	keyStackShape           = "stack.shape"
 	keySubmitFooter         = "submit.footer"
 	keySubmitDraft          = "submit.draft"
-	keySubmitGitHubStack    = "submit.githubStack"
+	keyGitHubStack          = "github.stack"
 	keySubmitWeb            = "submit.web"
 	keySubmitLabels         = "submit.labels"
 	keySubmitLabelsAdd      = "submit.labels.add"
@@ -157,8 +157,8 @@ func newConfigGetCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitFooter())
 			case keySubmitDraft:
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitDraft())
-			case keySubmitGitHubStack:
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitGitHubStack())
+			case keyGitHubStack:
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.GitHubStack())
 			case keySubmitWeb:
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitWeb())
 			case keySubmitLabels:
@@ -309,15 +309,15 @@ func newConfigSetCmd() *cobra.Command {
 					return fmt.Errorf("failed to set %s: %w", keySubmitDraft, err)
 				}
 				splog.Info("Set %s to: %v", keySubmitDraft, enabled)
-			case keySubmitGitHubStack:
+			case keyGitHubStack:
 				enabled, err := strconv.ParseBool(value)
 				if err != nil {
-					return fmt.Errorf("invalid value for %s: %s (must be 'true' or 'false')", keySubmitGitHubStack, value)
+					return fmt.Errorf("invalid value for %s: %s (must be 'true' or 'false')", keyGitHubStack, value)
 				}
-				if err := cfg.SetSubmitGitHubStack(enabled); err != nil {
-					return fmt.Errorf("failed to set %s: %w", keySubmitGitHubStack, err)
+				if err := cfg.SetGitHubStack(enabled); err != nil {
+					return fmt.Errorf("failed to set %s: %w", keyGitHubStack, err)
 				}
-				splog.Info("Set %s to: %v", keySubmitGitHubStack, enabled)
+				splog.Info("Set %s to: %v", keyGitHubStack, enabled)
 			case keySubmitWeb:
 				if err := cfg.SetSubmitWeb(value); err != nil {
 					return fmt.Errorf("failed to set %s: %w", keySubmitWeb, err)
@@ -514,11 +514,11 @@ Examples:
 					return fmt.Errorf("failed to unset %s: %w", keySubmitDraft, err)
 				}
 				splog.Info("Unset %s (now using: %v)", keySubmitDraft, cfg.SubmitDraft())
-			case keySubmitGitHubStack:
-				if err := cfg.UnsetSubmitGitHubStack(); err != nil {
-					return fmt.Errorf("failed to unset %s: %w", keySubmitGitHubStack, err)
+			case keyGitHubStack:
+				if err := cfg.UnsetGitHubStack(); err != nil {
+					return fmt.Errorf("failed to unset %s: %w", keyGitHubStack, err)
 				}
-				splog.Info("Unset %s (now using: %v)", keySubmitGitHubStack, cfg.SubmitGitHubStack())
+				splog.Info("Unset %s (now using: %v)", keyGitHubStack, cfg.GitHubStack())
 			case keySubmitWeb:
 				if err := cfg.UnsetSubmitWeb(); err != nil {
 					return fmt.Errorf("failed to unset %s: %w", keySubmitWeb, err)
@@ -886,9 +886,9 @@ func showConfigWithSources(repoRoot string, w io.Writer) error {
 	draftSource := getBoolSource(config.KeySubmitDraft, projectCfg != nil && projectCfg.HasSubmitDraft())
 	formatLine("submit.draft", strconv.FormatBool(cfg.SubmitDraft()), draftSource)
 
-	// submit.githubStack
-	githubStackSource := getBoolSource(config.KeySubmitGitHubStack, projectCfg != nil && projectCfg.HasSubmitGitHubStack())
-	formatLine(keySubmitGitHubStack, strconv.FormatBool(cfg.SubmitGitHubStack()), githubStackSource)
+	// github.stack
+	githubStackSource := getBoolSource(config.KeyGitHubStack, projectCfg != nil && projectCfg.HasGitHubStack())
+	formatLine(keyGitHubStack, strconv.FormatBool(cfg.GitHubStack()), githubStackSource)
 
 	// submit.web
 	webSource := getStringSource(config.KeySubmitWeb, projectCfg != nil && projectCfg.HasSubmitWeb())

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -31,6 +31,7 @@ const (
 	keyStackShape           = "stack.shape"
 	keySubmitFooter         = "submit.footer"
 	keySubmitDraft          = "submit.draft"
+	keySubmitGitHubStack    = "submit.githubStack"
 	keySubmitWeb            = "submit.web"
 	keySubmitLabels         = "submit.labels"
 	keySubmitLabelsAdd      = "submit.labels.add"
@@ -156,6 +157,8 @@ func newConfigGetCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitFooter())
 			case keySubmitDraft:
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitDraft())
+			case keySubmitGitHubStack:
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitGitHubStack())
 			case keySubmitWeb:
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SubmitWeb())
 			case keySubmitLabels:
@@ -306,6 +309,15 @@ func newConfigSetCmd() *cobra.Command {
 					return fmt.Errorf("failed to set %s: %w", keySubmitDraft, err)
 				}
 				splog.Info("Set %s to: %v", keySubmitDraft, enabled)
+			case keySubmitGitHubStack:
+				enabled, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("invalid value for %s: %s (must be 'true' or 'false')", keySubmitGitHubStack, value)
+				}
+				if err := cfg.SetSubmitGitHubStack(enabled); err != nil {
+					return fmt.Errorf("failed to set %s: %w", keySubmitGitHubStack, err)
+				}
+				splog.Info("Set %s to: %v", keySubmitGitHubStack, enabled)
 			case keySubmitWeb:
 				if err := cfg.SetSubmitWeb(value); err != nil {
 					return fmt.Errorf("failed to set %s: %w", keySubmitWeb, err)
@@ -502,6 +514,11 @@ Examples:
 					return fmt.Errorf("failed to unset %s: %w", keySubmitDraft, err)
 				}
 				splog.Info("Unset %s (now using: %v)", keySubmitDraft, cfg.SubmitDraft())
+			case keySubmitGitHubStack:
+				if err := cfg.UnsetSubmitGitHubStack(); err != nil {
+					return fmt.Errorf("failed to unset %s: %w", keySubmitGitHubStack, err)
+				}
+				splog.Info("Unset %s (now using: %v)", keySubmitGitHubStack, cfg.SubmitGitHubStack())
 			case keySubmitWeb:
 				if err := cfg.UnsetSubmitWeb(); err != nil {
 					return fmt.Errorf("failed to unset %s: %w", keySubmitWeb, err)
@@ -868,6 +885,10 @@ func showConfigWithSources(repoRoot string, w io.Writer) error {
 	// submit.draft
 	draftSource := getBoolSource(config.KeySubmitDraft, projectCfg != nil && projectCfg.HasSubmitDraft())
 	formatLine("submit.draft", strconv.FormatBool(cfg.SubmitDraft()), draftSource)
+
+	// submit.githubStack
+	githubStackSource := getBoolSource(config.KeySubmitGitHubStack, projectCfg != nil && projectCfg.HasSubmitGitHubStack())
+	formatLine(keySubmitGitHubStack, strconv.FormatBool(cfg.SubmitGitHubStack()), githubStackSource)
 
 	// submit.web
 	webSource := getStringSource(config.KeySubmitWeb, projectCfg != nil && projectCfg.HasSubmitWeb())

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -187,6 +187,31 @@ func TestConfigCommand(t *testing.T) {
 		require.Equal(t, "true", strings.TrimSpace(output))
 	})
 
+	t.Run("config set, get, and unset submit.githubStack", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)
+
+		output, err := s.RunCliAndGetOutput("config", "get", "submit.githubStack")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "false", strings.TrimSpace(output))
+
+		output, err = s.RunCliAndGetOutput("config", "set", "submit.githubStack", "true")
+		require.NoError(t, err, "config set command failed: %s", output)
+		require.Contains(t, output, "Set submit.githubStack to: true")
+
+		output, err = s.RunCliAndGetOutput("config", "get", "submit.githubStack")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "true", strings.TrimSpace(output))
+
+		output, err = s.RunCliAndGetOutput("config", "unset", "submit.githubStack")
+		require.NoError(t, err, "config unset command failed: %s", output)
+		require.Contains(t, output, "Unset submit.githubStack")
+
+		output, err = s.RunCliAndGetOutput("config", "get", "submit.githubStack")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "false", strings.TrimSpace(output))
+	})
+
 	t.Run("config set get and unset undo.enabled", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -187,27 +187,27 @@ func TestConfigCommand(t *testing.T) {
 		require.Equal(t, "true", strings.TrimSpace(output))
 	})
 
-	t.Run("config set, get, and unset submit.githubStack", func(t *testing.T) {
+	t.Run("config set, get, and unset github.stack", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
-		output, err := s.RunCliAndGetOutput("config", "get", "submit.githubStack")
+		output, err := s.RunCliAndGetOutput("config", "get", "github.stack")
 		require.NoError(t, err, "config get command failed: %s", output)
 		require.Equal(t, "false", strings.TrimSpace(output))
 
-		output, err = s.RunCliAndGetOutput("config", "set", "submit.githubStack", "true")
+		output, err = s.RunCliAndGetOutput("config", "set", "github.stack", "true")
 		require.NoError(t, err, "config set command failed: %s", output)
-		require.Contains(t, output, "Set submit.githubStack to: true")
+		require.Contains(t, output, "Set github.stack to: true")
 
-		output, err = s.RunCliAndGetOutput("config", "get", "submit.githubStack")
+		output, err = s.RunCliAndGetOutput("config", "get", "github.stack")
 		require.NoError(t, err, "config get command failed: %s", output)
 		require.Equal(t, "true", strings.TrimSpace(output))
 
-		output, err = s.RunCliAndGetOutput("config", "unset", "submit.githubStack")
+		output, err = s.RunCliAndGetOutput("config", "unset", "github.stack")
 		require.NoError(t, err, "config unset command failed: %s", output)
-		require.Contains(t, output, "Unset submit.githubStack")
+		require.Contains(t, output, "Unset github.stack")
 
-		output, err = s.RunCliAndGetOutput("config", "get", "submit.githubStack")
+		output, err = s.RunCliAndGetOutput("config", "get", "github.stack")
 		require.NoError(t, err, "config get command failed: %s", output)
 		require.Equal(t, "false", strings.TrimSpace(output))
 	})

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -80,7 +80,7 @@ func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
 	cmd.Flags().BoolVar(&f.noAssignees, "no-assignees", false, "Don't apply default assignees from config.")
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output the plan and per-branch results as JSON.")
 	cmd.Flags().BoolVar(&f.verbose, "verbose", false, "Show the full branch-by-branch submission plan and results.")
-	cmd.Flags().BoolVar(&f.withNativeStack, "with-native-stack", false, "Sync native GitHub Stack metadata once (or enable submit.githubStack for eligible submits).")
+	cmd.Flags().BoolVar(&f.withNativeStack, "with-native-stack", false, "Sync native GitHub Stack metadata once (or enable github.stack for eligible submits).")
 }
 
 func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
@@ -136,7 +136,7 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 			CreateGitHubStack:    f.withNativeStack,
 			// Config-driven options
 			ConfigDraft:       cfg.SubmitDraft(),
-			ConfigGitHubStack: cfg.SubmitGitHubStack(),
+			ConfigGitHubStack: cfg.GitHubStack(),
 			ConfigWeb:         cfg.SubmitWeb(),
 			ConfigLabels:      configLabels,
 			ConfigReviewers:   cfg.SubmitReviewers(),

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -46,6 +46,7 @@ type submitFlags struct {
 	noAssignees          bool
 	jsonOutput           bool
 	verbose              bool
+	withNativeStack      bool
 }
 
 func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
@@ -79,6 +80,7 @@ func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
 	cmd.Flags().BoolVar(&f.noAssignees, "no-assignees", false, "Don't apply default assignees from config.")
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output the plan and per-branch results as JSON.")
 	cmd.Flags().BoolVar(&f.verbose, "verbose", false, "Show the full branch-by-branch submission plan and results.")
+	cmd.Flags().BoolVar(&f.withNativeStack, "with-native-stack", false, "Sync native GitHub Stack metadata after submitting a linear Stackit PR chain.")
 }
 
 func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
@@ -131,6 +133,7 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 			SubmitFooter:         submitFooter,
 			NoLabels:             f.noLabels,
 			NoAssignees:          f.noAssignees,
+			CreateGitHubStack:    f.withNativeStack,
 			// Config-driven options
 			ConfigDraft:     cfg.SubmitDraft(),
 			ConfigWeb:       cfg.SubmitWeb(),

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -80,7 +80,7 @@ func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
 	cmd.Flags().BoolVar(&f.noAssignees, "no-assignees", false, "Don't apply default assignees from config.")
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output the plan and per-branch results as JSON.")
 	cmd.Flags().BoolVar(&f.verbose, "verbose", false, "Show the full branch-by-branch submission plan and results.")
-	cmd.Flags().BoolVar(&f.withNativeStack, "with-native-stack", false, "Sync native GitHub Stack metadata after submitting a linear Stackit PR chain.")
+	cmd.Flags().BoolVar(&f.withNativeStack, "with-native-stack", false, "Sync native GitHub Stack metadata once (or enable submit.githubStack for eligible submits).")
 }
 
 func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
@@ -135,11 +135,12 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 			NoAssignees:          f.noAssignees,
 			CreateGitHubStack:    f.withNativeStack,
 			// Config-driven options
-			ConfigDraft:     cfg.SubmitDraft(),
-			ConfigWeb:       cfg.SubmitWeb(),
-			ConfigLabels:    configLabels,
-			ConfigReviewers: cfg.SubmitReviewers(),
-			ConfigAssignees: configAssignees,
+			ConfigDraft:       cfg.SubmitDraft(),
+			ConfigGitHubStack: cfg.SubmitGitHubStack(),
+			ConfigWeb:         cfg.SubmitWeb(),
+			ConfigLabels:      configLabels,
+			ConfigReviewers:   cfg.SubmitReviewers(),
+			ConfigAssignees:   configAssignees,
 		}
 
 		if f.jsonOutput {

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/submit"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
 	submitComponent "github.com/getstackit/stackit/internal/tui/components/submit"
@@ -465,8 +466,8 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 	case submit.BranchWarningEvent:
 		h.Output.Warn("%s: %s", submitComponent.DisplayBranchName(ev.BranchName), ev.Warning)
 
-	case submit.GitHubStackCreatedEvent:
-		h.Output.Success("Created native GitHub Stack #%d from %s.", ev.Number, formatGitHubStackPRs(ev.PullRequests))
+	case submit.GitHubStackSyncedEvent:
+		h.Output.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(ev.Action), ev.Number, formatGitHubStackPRs(ev.PullRequests))
 
 	case submit.CompletionEvent:
 		h.plan.Flush()
@@ -585,7 +586,7 @@ type InteractiveSubmitHandler struct {
 	out           output.Output
 	plan          planPrinter
 	inSubmitPhase bool
-	githubStack   *submit.GitHubStackCreatedEvent
+	githubStack   *submit.GitHubStackSyncedEvent
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
@@ -663,13 +664,13 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		}
 		h.out.Warn("%s: %s", submitComponent.DisplayBranchName(ev.BranchName), ev.Warning)
 
-	case submit.GitHubStackCreatedEvent:
+	case submit.GitHubStackSyncedEvent:
 		if h.runner.IsRunning() {
 			created := ev
 			h.githubStack = &created
 			return
 		}
-		h.out.Success("Created native GitHub Stack #%d from %s.", ev.Number, formatGitHubStackPRs(ev.PullRequests))
+		h.out.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(ev.Action), ev.Number, formatGitHubStackPRs(ev.PullRequests))
 
 	case submit.CompletionEvent:
 		h.plan.Flush()
@@ -693,7 +694,7 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		})
 		h.runner.Wait()
 		if h.githubStack != nil {
-			h.out.Success("Created native GitHub Stack #%d from %s.", h.githubStack.Number, formatGitHubStackPRs(h.githubStack.PullRequests))
+			h.out.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(h.githubStack.Action), h.githubStack.Number, formatGitHubStackPRs(h.githubStack.PullRequests))
 		}
 	}
 }
@@ -704,6 +705,17 @@ func formatGitHubStackPRs(pullRequests []int) string {
 		formatted[i] = fmt.Sprintf("#%d", number)
 	}
 	return strings.Join(formatted, " → ")
+}
+
+func githubStackActionLabel(action github.StackSyncAction) string {
+	switch action {
+	case github.StackSyncCreated:
+		return "Created"
+	case github.StackSyncExtended:
+		return "Extended"
+	default:
+		return "Already linked to"
+	}
 }
 
 // Confirm prompts for user confirmation

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -465,6 +465,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 	case submit.BranchWarningEvent:
 		h.Output.Warn("%s: %s", submitComponent.DisplayBranchName(ev.BranchName), ev.Warning)
 
+	case submit.GitHubStackCreatedEvent:
+		h.Output.Success("Created native GitHub Stack #%d from %s.", ev.Number, formatGitHubStackPRs(ev.PullRequests))
+
 	case submit.CompletionEvent:
 		h.plan.Flush()
 		switch ev.Outcome {
@@ -582,6 +585,7 @@ type InteractiveSubmitHandler struct {
 	out           output.Output
 	plan          planPrinter
 	inSubmitPhase bool
+	githubStack   *submit.GitHubStackCreatedEvent
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
@@ -659,6 +663,14 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		}
 		h.out.Warn("%s: %s", submitComponent.DisplayBranchName(ev.BranchName), ev.Warning)
 
+	case submit.GitHubStackCreatedEvent:
+		if h.runner.IsRunning() {
+			created := ev
+			h.githubStack = &created
+			return
+		}
+		h.out.Success("Created native GitHub Stack #%d from %s.", ev.Number, formatGitHubStackPRs(ev.PullRequests))
+
 	case submit.CompletionEvent:
 		h.plan.Flush()
 		// If the submission phase never started (nothing to submit, dry run,
@@ -680,7 +692,18 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			Elapsed: ev.Duration,
 		})
 		h.runner.Wait()
+		if h.githubStack != nil {
+			h.out.Success("Created native GitHub Stack #%d from %s.", h.githubStack.Number, formatGitHubStackPRs(h.githubStack.PullRequests))
+		}
 	}
+}
+
+func formatGitHubStackPRs(pullRequests []int) string {
+	formatted := make([]string, len(pullRequests))
+	for i, number := range pullRequests {
+		formatted[i] = fmt.Sprintf("#%d", number)
+	}
+	return strings.Join(formatted, " → ")
 }
 
 // Confirm prompts for user confirmation

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -696,21 +696,21 @@ func (c *GitConfig) SetSubmitDraft(draft bool) error {
 	return c.store.SetBool(KeySubmitDraft, draft)
 }
 
-// SubmitGitHubStack returns whether submit should sync native GitHub Stack metadata.
+// GitHubStack returns whether Stackit should sync native GitHub Stack metadata.
 // Priority: personal git config > team project config > default.
-func (c *GitConfig) SubmitGitHubStack() bool {
-	if c.store.Exists(KeySubmitGitHubStack) {
-		return c.store.GetBoolWithDefault(KeySubmitGitHubStack, DefaultSubmitGitHubStack)
+func (c *GitConfig) GitHubStack() bool {
+	if c.store.Exists(KeyGitHubStack) {
+		return c.store.GetBoolWithDefault(KeyGitHubStack, DefaultGitHubStack)
 	}
-	if c.project != nil && c.project.HasSubmitGitHubStack() {
-		return c.project.GetSubmitGitHubStack()
+	if c.project != nil && c.project.HasGitHubStack() {
+		return c.project.GetGitHubStack()
 	}
-	return DefaultSubmitGitHubStack
+	return DefaultGitHubStack
 }
 
-// SetSubmitGitHubStack sets whether submit syncs native GitHub Stack metadata.
-func (c *GitConfig) SetSubmitGitHubStack(enabled bool) error {
-	return c.store.SetBool(KeySubmitGitHubStack, enabled)
+// SetGitHubStack sets whether Stackit syncs native GitHub Stack metadata.
+func (c *GitConfig) SetGitHubStack(enabled bool) error {
+	return c.store.SetBool(KeyGitHubStack, enabled)
 }
 
 // SubmitWeb returns when to open PRs in browser.
@@ -1010,9 +1010,9 @@ func (c *GitConfig) UnsetSubmitDraft() error {
 	return c.store.Unset(KeySubmitDraft)
 }
 
-// UnsetSubmitGitHubStack removes the personal GitHub Stack sync setting.
-func (c *GitConfig) UnsetSubmitGitHubStack() error {
-	return c.store.Unset(KeySubmitGitHubStack)
+// UnsetGitHubStack removes the personal GitHub Stack sync setting.
+func (c *GitConfig) UnsetGitHubStack() error {
+	return c.store.Unset(KeyGitHubStack)
 }
 
 // UnsetSubmitWeb removes the personal submit.web setting, reverting to project/default.
@@ -1045,7 +1045,7 @@ func (c *GitConfig) ResetAllPersonal() error {
 		KeyStackShape,
 		KeySubmitFooter,
 		KeySubmitDraft,
-		KeySubmitGitHubStack,
+		KeyGitHubStack,
 		KeySubmitWeb,
 		KeySubmitLabels,
 		KeySubmitReviewers,

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -696,6 +696,23 @@ func (c *GitConfig) SetSubmitDraft(draft bool) error {
 	return c.store.SetBool(KeySubmitDraft, draft)
 }
 
+// SubmitGitHubStack returns whether submit should sync native GitHub Stack metadata.
+// Priority: personal git config > team project config > default.
+func (c *GitConfig) SubmitGitHubStack() bool {
+	if c.store.Exists(KeySubmitGitHubStack) {
+		return c.store.GetBoolWithDefault(KeySubmitGitHubStack, DefaultSubmitGitHubStack)
+	}
+	if c.project != nil && c.project.HasSubmitGitHubStack() {
+		return c.project.GetSubmitGitHubStack()
+	}
+	return DefaultSubmitGitHubStack
+}
+
+// SetSubmitGitHubStack sets whether submit syncs native GitHub Stack metadata.
+func (c *GitConfig) SetSubmitGitHubStack(enabled bool) error {
+	return c.store.SetBool(KeySubmitGitHubStack, enabled)
+}
+
 // SubmitWeb returns when to open PRs in browser.
 // Priority: personal git config > team project config > default.
 func (c *GitConfig) SubmitWeb() string {
@@ -993,6 +1010,11 @@ func (c *GitConfig) UnsetSubmitDraft() error {
 	return c.store.Unset(KeySubmitDraft)
 }
 
+// UnsetSubmitGitHubStack removes the personal GitHub Stack sync setting.
+func (c *GitConfig) UnsetSubmitGitHubStack() error {
+	return c.store.Unset(KeySubmitGitHubStack)
+}
+
 // UnsetSubmitWeb removes the personal submit.web setting, reverting to project/default.
 func (c *GitConfig) UnsetSubmitWeb() error {
 	return c.store.Unset(KeySubmitWeb)
@@ -1023,6 +1045,7 @@ func (c *GitConfig) ResetAllPersonal() error {
 		KeyStackShape,
 		KeySubmitFooter,
 		KeySubmitDraft,
+		KeySubmitGitHubStack,
 		KeySubmitWeb,
 		KeySubmitLabels,
 		KeySubmitReviewers,

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -1165,7 +1165,7 @@ func TestGitConfigSubmitDraft(t *testing.T) {
 	})
 }
 
-func TestGitConfigSubmitGitHubStack(t *testing.T) {
+func TestGitConfigGitHubStack(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns default when not set", func(t *testing.T) {
@@ -1174,7 +1174,7 @@ func TestGitConfigSubmitGitHubStack(t *testing.T) {
 
 		cfg, err := LoadGitConfig(scene.Dir)
 		require.NoError(t, err)
-		require.False(t, cfg.SubmitGitHubStack())
+		require.False(t, cfg.GitHubStack())
 	})
 
 	t.Run("sets and unsets native GitHub Stack sync", func(t *testing.T) {
@@ -1183,10 +1183,10 @@ func TestGitConfigSubmitGitHubStack(t *testing.T) {
 
 		cfg, err := LoadGitConfig(scene.Dir)
 		require.NoError(t, err)
-		require.NoError(t, cfg.SetSubmitGitHubStack(true))
-		require.True(t, cfg.SubmitGitHubStack())
-		require.NoError(t, cfg.UnsetSubmitGitHubStack())
-		require.False(t, cfg.SubmitGitHubStack())
+		require.NoError(t, cfg.SetGitHubStack(true))
+		require.True(t, cfg.GitHubStack())
+		require.NoError(t, cfg.UnsetGitHubStack())
+		require.False(t, cfg.GitHubStack())
 	})
 }
 
@@ -1414,20 +1414,20 @@ func TestGitConfigSubmitWithProjectConfig(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 		removeDefaultConfig(t, scene.Dir)
 
-		projectConfig := `submit:
-  githubStack: true
+		projectConfig := `github:
+  stack: true
 `
 		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
 		require.NoError(t, err)
 
 		cfg, err := LoadGitConfigWithProject(scene.Dir)
 		require.NoError(t, err)
-		require.True(t, cfg.SubmitGitHubStack())
+		require.True(t, cfg.GitHubStack())
 
-		require.NoError(t, cfg.SetSubmitGitHubStack(false))
-		require.False(t, cfg.SubmitGitHubStack())
-		require.NoError(t, cfg.UnsetSubmitGitHubStack())
-		require.True(t, cfg.SubmitGitHubStack())
+		require.NoError(t, cfg.SetGitHubStack(false))
+		require.False(t, cfg.GitHubStack())
+		require.NoError(t, cfg.UnsetGitHubStack())
+		require.True(t, cfg.GitHubStack())
 	})
 
 	t.Run("draft falls back to project config", func(t *testing.T) {

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -1165,6 +1165,31 @@ func TestGitConfigSubmitDraft(t *testing.T) {
 	})
 }
 
+func TestGitConfigSubmitGitHubStack(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns default when not set", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadGitConfig(scene.Dir)
+		require.NoError(t, err)
+		require.False(t, cfg.SubmitGitHubStack())
+	})
+
+	t.Run("sets and unsets native GitHub Stack sync", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadGitConfig(scene.Dir)
+		require.NoError(t, err)
+		require.NoError(t, cfg.SetSubmitGitHubStack(true))
+		require.True(t, cfg.SubmitGitHubStack())
+		require.NoError(t, cfg.UnsetSubmitGitHubStack())
+		require.False(t, cfg.SubmitGitHubStack())
+	})
+}
+
 func TestGitConfigSubmitWeb(t *testing.T) {
 	t.Parallel()
 
@@ -1383,6 +1408,27 @@ func TestGitConfigSubmitAssignees(t *testing.T) {
 
 func TestGitConfigSubmitWithProjectConfig(t *testing.T) {
 	t.Parallel()
+
+	t.Run("GitHub Stack sync falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		projectConfig := `submit:
+  githubStack: true
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+		require.True(t, cfg.SubmitGitHubStack())
+
+		require.NoError(t, cfg.SetSubmitGitHubStack(false))
+		require.False(t, cfg.SubmitGitHubStack())
+		require.NoError(t, cfg.UnsetSubmitGitHubStack())
+		require.True(t, cfg.SubmitGitHubStack())
+	})
 
 	t.Run("draft falls back to project config", func(t *testing.T) {
 		t.Parallel()

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -17,12 +17,14 @@ func TestGenerateConfigDocs(t *testing.T) {
 	assert.Contains(t, docs, "## Branch naming")
 	assert.Contains(t, docs, "## Stack topology")
 	assert.Contains(t, docs, "## PR submission")
+	assert.Contains(t, docs, "## GitHub integration")
 	assert.Contains(t, docs, "## PR navigation")
 
 	// Should have option documentation
 	assert.Contains(t, docs, "### branch.pattern")
 	assert.Contains(t, docs, "### stack.shape")
 	assert.Contains(t, docs, "### submit.footer")
+	assert.Contains(t, docs, "### github.stack")
 	assert.Contains(t, docs, "### navigation.when")
 
 	// Should have examples

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -20,6 +20,7 @@ type Configurer interface {
 
 	// Submit settings
 	SubmitFooter() bool
+	SubmitGitHubStack() bool
 
 	// Undo settings
 	UndoStackDepth() int

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -20,7 +20,9 @@ type Configurer interface {
 
 	// Submit settings
 	SubmitFooter() bool
-	SubmitGitHubStack() bool
+
+	// GitHub integration settings
+	GitHubStack() bool
 
 	// Undo settings
 	UndoStackDepth() int

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -52,6 +52,8 @@ const (
 	KeyNavigationShowMerged = "stackit.navigation.showMerged"
 	// KeySubmitDraft controls whether to create PRs as drafts by default.
 	KeySubmitDraft = "stackit.submit.draft"
+	// KeySubmitGitHubStack controls whether submit reconciles native GitHub Stack metadata.
+	KeySubmitGitHubStack = "stackit.submit.githubStack"
 	// KeySubmitWeb controls when to open PRs in browser (always/created/never).
 	KeySubmitWeb = "stackit.submit.web"
 	// KeySubmitLabels stores default labels for PRs (multi-value).
@@ -71,6 +73,7 @@ const (
 	YAMLPathStackShape           = "stack.shape"
 	YAMLPathSubmitFooter         = "submit.footer"
 	YAMLPathSubmitDraft          = "submit.draft"
+	YAMLPathSubmitGitHubStack    = "submit.githubStack"
 	YAMLPathSubmitWeb            = "submit.web"
 	YAMLPathSubmitLabels         = "submit.labels"
 	YAMLPathSubmitReviewers      = "submit.reviewers"
@@ -122,6 +125,8 @@ const (
 	DefaultNavigationShowMerged = true
 	// DefaultSubmitDraft is whether to create PRs as drafts by default.
 	DefaultSubmitDraft = false
+	// DefaultSubmitGitHubStack is whether submit syncs native GitHub Stack metadata.
+	DefaultSubmitGitHubStack = false
 	// DefaultSubmitWeb is when to open PRs in browser by default.
 	DefaultSubmitWeb = "never"
 )

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -52,8 +52,8 @@ const (
 	KeyNavigationShowMerged = "stackit.navigation.showMerged"
 	// KeySubmitDraft controls whether to create PRs as drafts by default.
 	KeySubmitDraft = "stackit.submit.draft"
-	// KeySubmitGitHubStack controls whether submit reconciles native GitHub Stack metadata.
-	KeySubmitGitHubStack = "stackit.submit.githubStack"
+	// KeyGitHubStack controls whether Stackit reconciles native GitHub Stack metadata.
+	KeyGitHubStack = "stackit.github.stack"
 	// KeySubmitWeb controls when to open PRs in browser (always/created/never).
 	KeySubmitWeb = "stackit.submit.web"
 	// KeySubmitLabels stores default labels for PRs (multi-value).
@@ -73,7 +73,7 @@ const (
 	YAMLPathStackShape           = "stack.shape"
 	YAMLPathSubmitFooter         = "submit.footer"
 	YAMLPathSubmitDraft          = "submit.draft"
-	YAMLPathSubmitGitHubStack    = "submit.githubStack"
+	YAMLPathGitHubStack          = "github.stack"
 	YAMLPathSubmitWeb            = "submit.web"
 	YAMLPathSubmitLabels         = "submit.labels"
 	YAMLPathSubmitReviewers      = "submit.reviewers"
@@ -125,8 +125,8 @@ const (
 	DefaultNavigationShowMerged = true
 	// DefaultSubmitDraft is whether to create PRs as drafts by default.
 	DefaultSubmitDraft = false
-	// DefaultSubmitGitHubStack is whether submit syncs native GitHub Stack metadata.
-	DefaultSubmitGitHubStack = false
+	// DefaultGitHubStack is whether Stackit syncs native GitHub Stack metadata.
+	DefaultGitHubStack = false
 	// DefaultSubmitWeb is when to open PRs in browser by default.
 	DefaultSubmitWeb = "never"
 )
@@ -139,6 +139,7 @@ const (
 	SectionBranch      = "branch"
 	SectionStack       = "stack"
 	SectionSubmit      = "submit"
+	SectionGitHub      = "github"
 	SectionMerge       = "merge"
 	SectionCI          = "ci"
 	SectionUndo        = "undo"

--- a/internal/config/metadata.go
+++ b/internal/config/metadata.go
@@ -41,6 +41,7 @@ var Sections = []Section{
 	{Name: SectionBranch, Title: "Branch naming pattern", DocsTitle: "Branch naming"},
 	{Name: SectionStack, Title: "Stack topology", DocsTitle: "Stack topology"},
 	{Name: SectionSubmit, Title: "PR submission settings", DocsTitle: "PR submission"},
+	{Name: SectionGitHub, Title: "GitHub integration", DocsTitle: "GitHub integration"},
 	{Name: SectionMerge, Title: "Merge method: squash, merge, rebase", DocsTitle: "Merge settings"},
 	{Name: SectionCI, Title: "CI validation", DocsTitle: "CI validation"},
 	{Name: SectionUndo, Title: "Undo history", DocsTitle: "Other settings"},
@@ -105,13 +106,6 @@ var Options = []Option{
 		Section:     SectionSubmit,
 	},
 	{
-		YAMLPath:    YAMLPathSubmitGitHubStack,
-		GitKey:      KeySubmitGitHubStack,
-		Description: "Sync native GitHub Stack metadata for eligible linear PR chains",
-		Default:     DefaultSubmitGitHubStack,
-		Section:     SectionSubmit,
-	},
-	{
 		YAMLPath:    YAMLPathSubmitWeb,
 		GitKey:      KeySubmitWeb,
 		Description: "Open in browser: always, created, never",
@@ -139,6 +133,15 @@ var Options = []Option{
 		Description: "Default assignees",
 		IsArray:     true,
 		Section:     SectionSubmit,
+	},
+
+	// GitHub integration section
+	{
+		YAMLPath:    YAMLPathGitHubStack,
+		GitKey:      KeyGitHubStack,
+		Description: "Sync native Stack metadata for eligible linear PR chains",
+		Default:     DefaultGitHubStack,
+		Section:     SectionGitHub,
 	},
 
 	// Merge section

--- a/internal/config/metadata.go
+++ b/internal/config/metadata.go
@@ -105,6 +105,13 @@ var Options = []Option{
 		Section:     SectionSubmit,
 	},
 	{
+		YAMLPath:    YAMLPathSubmitGitHubStack,
+		GitKey:      KeySubmitGitHubStack,
+		Description: "Sync native GitHub Stack metadata for eligible linear PR chains",
+		Default:     DefaultSubmitGitHubStack,
+		Section:     SectionSubmit,
+	},
+	{
 		YAMLPath:    YAMLPathSubmitWeb,
 		GitKey:      KeySubmitWeb,
 		Description: "Open in browser: always, created, never",

--- a/internal/config/metadata_test.go
+++ b/internal/config/metadata_test.go
@@ -33,7 +33,7 @@ func TestOptionsCoversAllKeys(t *testing.T) {
 		KeyNavigationLocation,
 		KeyNavigationShowMerged,
 		KeySubmitDraft,
-		KeySubmitGitHubStack,
+		KeyGitHubStack,
 		KeySubmitWeb,
 		KeySubmitLabels,
 		KeySubmitReviewers,

--- a/internal/config/metadata_test.go
+++ b/internal/config/metadata_test.go
@@ -33,6 +33,7 @@ func TestOptionsCoversAllKeys(t *testing.T) {
 		KeyNavigationLocation,
 		KeyNavigationShowMerged,
 		KeySubmitDraft,
+		KeySubmitGitHubStack,
 		KeySubmitWeb,
 		KeySubmitLabels,
 		KeySubmitReviewers,

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -28,12 +28,13 @@ type StackConfig struct {
 
 // SubmitConfig contains PR submission configuration
 type SubmitConfig struct {
-	Footer    *bool    `yaml:"footer,omitempty"`    // Pointer to distinguish unset from false
-	Draft     *bool    `yaml:"draft,omitempty"`     // Pointer to distinguish unset from false
-	Web       string   `yaml:"web,omitempty"`       // "always", "created", "never"
-	Labels    []string `yaml:"labels,omitempty"`    // Default labels for PRs
-	Reviewers []string `yaml:"reviewers,omitempty"` // Default reviewers for PRs
-	Assignees []string `yaml:"assignees,omitempty"` // Default assignees for PRs
+	Footer      *bool    `yaml:"footer,omitempty"`      // Pointer to distinguish unset from false
+	Draft       *bool    `yaml:"draft,omitempty"`       // Pointer to distinguish unset from false
+	GitHubStack *bool    `yaml:"githubStack,omitempty"` // Sync native GitHub Stack metadata
+	Web         string   `yaml:"web,omitempty"`         // "always", "created", "never"
+	Labels      []string `yaml:"labels,omitempty"`      // Default labels for PRs
+	Reviewers   []string `yaml:"reviewers,omitempty"`   // Default reviewers for PRs
+	Assignees   []string `yaml:"assignees,omitempty"`   // Default assignees for PRs
 }
 
 // MergeConfig contains merge method configuration
@@ -206,6 +207,19 @@ func (c *ProjectConfig) GetSubmitDraft() bool {
 		return false // Default
 	}
 	return *c.Submit.Draft
+}
+
+// HasSubmitGitHubStack returns true if native GitHub Stack sync is configured.
+func (c *ProjectConfig) HasSubmitGitHubStack() bool {
+	return c.Submit.GitHubStack != nil
+}
+
+// GetSubmitGitHubStack returns the native GitHub Stack sync value.
+func (c *ProjectConfig) GetSubmitGitHubStack() bool {
+	if c.Submit.GitHubStack == nil {
+		return DefaultSubmitGitHubStack
+	}
+	return *c.Submit.GitHubStack
 }
 
 // HasSubmitWeb returns true if the submit web setting is configured

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -28,13 +28,17 @@ type StackConfig struct {
 
 // SubmitConfig contains PR submission configuration
 type SubmitConfig struct {
-	Footer      *bool    `yaml:"footer,omitempty"`      // Pointer to distinguish unset from false
-	Draft       *bool    `yaml:"draft,omitempty"`       // Pointer to distinguish unset from false
-	GitHubStack *bool    `yaml:"githubStack,omitempty"` // Sync native GitHub Stack metadata
-	Web         string   `yaml:"web,omitempty"`         // "always", "created", "never"
-	Labels      []string `yaml:"labels,omitempty"`      // Default labels for PRs
-	Reviewers   []string `yaml:"reviewers,omitempty"`   // Default reviewers for PRs
-	Assignees   []string `yaml:"assignees,omitempty"`   // Default assignees for PRs
+	Footer    *bool    `yaml:"footer,omitempty"`    // Pointer to distinguish unset from false
+	Draft     *bool    `yaml:"draft,omitempty"`     // Pointer to distinguish unset from false
+	Web       string   `yaml:"web,omitempty"`       // "always", "created", "never"
+	Labels    []string `yaml:"labels,omitempty"`    // Default labels for PRs
+	Reviewers []string `yaml:"reviewers,omitempty"` // Default reviewers for PRs
+	Assignees []string `yaml:"assignees,omitempty"` // Default assignees for PRs
+}
+
+// GitHubConfig contains GitHub integration configuration.
+type GitHubConfig struct {
+	Stack *bool `yaml:"stack,omitempty"` // Sync native GitHub Stack metadata
 }
 
 // MergeConfig contains merge method configuration
@@ -83,6 +87,7 @@ type ProjectConfig struct {
 	Branch         BranchConfig     `yaml:"branch,omitempty"`
 	Stack          StackConfig      `yaml:"stack,omitempty"`
 	Submit         SubmitConfig     `yaml:"submit,omitempty"`
+	GitHub         GitHubConfig     `yaml:"github,omitempty"`
 	Merge          MergeConfig      `yaml:"merge,omitempty"`
 	CI             CIConfig         `yaml:"ci,omitempty"`
 	Undo           UndoConfig       `yaml:"undo,omitempty"`
@@ -111,6 +116,7 @@ var knownTopLevelKeys = map[string]bool{
 	SectionBranch:     true,
 	SectionStack:      true,
 	SectionSubmit:     true,
+	SectionGitHub:     true,
 	SectionMerge:      true,
 	SectionCI:         true,
 	SectionUndo:       true,
@@ -209,17 +215,17 @@ func (c *ProjectConfig) GetSubmitDraft() bool {
 	return *c.Submit.Draft
 }
 
-// HasSubmitGitHubStack returns true if native GitHub Stack sync is configured.
-func (c *ProjectConfig) HasSubmitGitHubStack() bool {
-	return c.Submit.GitHubStack != nil
+// HasGitHubStack returns true if native GitHub Stack sync is configured.
+func (c *ProjectConfig) HasGitHubStack() bool {
+	return c.GitHub.Stack != nil
 }
 
-// GetSubmitGitHubStack returns the native GitHub Stack sync value.
-func (c *ProjectConfig) GetSubmitGitHubStack() bool {
-	if c.Submit.GitHubStack == nil {
-		return DefaultSubmitGitHubStack
+// GetGitHubStack returns the native GitHub Stack sync value.
+func (c *ProjectConfig) GetGitHubStack() bool {
+	if c.GitHub.Stack == nil {
+		return DefaultGitHubStack
 	}
-	return *c.Submit.GitHubStack
+	return *c.GitHub.Stack
 }
 
 // HasSubmitWeb returns true if the submit web setting is configured

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -174,6 +174,7 @@ branch:
 
 submit:
   footer: false
+  githubStack: true
 
 merge:
   method: squash
@@ -196,6 +197,7 @@ hooks:
 		assert.Equal(t, []string{"staging", "production"}, cfg.Trunks)
 		assert.Equal(t, "feature/{message}", cfg.Branch.Pattern)
 		assert.False(t, cfg.GetSubmitFooter())
+		assert.True(t, cfg.GetSubmitGitHubStack())
 		assert.Equal(t, "squash", cfg.Merge.Method)
 		assert.Equal(t, "make test", cfg.CI.Command)
 		assert.Equal(t, 300, cfg.CI.Timeout)
@@ -264,6 +266,17 @@ func TestProjectConfigHelpers(t *testing.T) {
 		cfg.Submit.Footer = &footer
 		assert.True(t, cfg.HasSubmitFooter())
 		assert.False(t, cfg.GetSubmitFooter())
+	})
+
+	t.Run("HasSubmitGitHubStack and GetSubmitGitHubStack", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasSubmitGitHubStack())
+		assert.False(t, cfg.GetSubmitGitHubStack())
+
+		enabled := true
+		cfg.Submit.GitHubStack = &enabled
+		assert.True(t, cfg.HasSubmitGitHubStack())
+		assert.True(t, cfg.GetSubmitGitHubStack())
 	})
 
 	t.Run("HasMergeMethod", func(t *testing.T) {

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -174,7 +174,9 @@ branch:
 
 submit:
   footer: false
-  githubStack: true
+
+github:
+  stack: true
 
 merge:
   method: squash
@@ -197,7 +199,7 @@ hooks:
 		assert.Equal(t, []string{"staging", "production"}, cfg.Trunks)
 		assert.Equal(t, "feature/{message}", cfg.Branch.Pattern)
 		assert.False(t, cfg.GetSubmitFooter())
-		assert.True(t, cfg.GetSubmitGitHubStack())
+		assert.True(t, cfg.GetGitHubStack())
 		assert.Equal(t, "squash", cfg.Merge.Method)
 		assert.Equal(t, "make test", cfg.CI.Command)
 		assert.Equal(t, 300, cfg.CI.Timeout)
@@ -268,15 +270,15 @@ func TestProjectConfigHelpers(t *testing.T) {
 		assert.False(t, cfg.GetSubmitFooter())
 	})
 
-	t.Run("HasSubmitGitHubStack and GetSubmitGitHubStack", func(t *testing.T) {
+	t.Run("HasGitHubStack and GetGitHubStack", func(t *testing.T) {
 		cfg := &ProjectConfig{}
-		assert.False(t, cfg.HasSubmitGitHubStack())
-		assert.False(t, cfg.GetSubmitGitHubStack())
+		assert.False(t, cfg.HasGitHubStack())
+		assert.False(t, cfg.GetGitHubStack())
 
 		enabled := true
-		cfg.Submit.GitHubStack = &enabled
-		assert.True(t, cfg.HasSubmitGitHubStack())
-		assert.True(t, cfg.GetSubmitGitHubStack())
+		cfg.GitHub.Stack = &enabled
+		assert.True(t, cfg.HasGitHubStack())
+		assert.True(t, cfg.GetGitHubStack())
 	})
 
 	t.Run("HasMergeMethod", func(t *testing.T) {

--- a/internal/config/testdata/config_template.golden
+++ b/internal/config/testdata/config_template.golden
@@ -22,11 +22,14 @@
 # submit:
 #   footer: true # Include navigation footer
 #   draft: false # Create as draft
-#   githubStack: false # Sync native GitHub Stack metadata for eligible linear PR chains
 #   web: never # Open in browser: always, created, never
 #   labels: [] # Default labels
 #   reviewers: [] # Default reviewers
 #   assignees: [] # Default assignees
+
+# GitHub integration
+# github:
+#   stack: false # Sync native Stack metadata for eligible linear PR chains
 
 # Merge method: squash, merge, rebase
 # merge:

--- a/internal/config/testdata/config_template.golden
+++ b/internal/config/testdata/config_template.golden
@@ -22,6 +22,7 @@
 # submit:
 #   footer: true # Include navigation footer
 #   draft: false # Create as draft
+#   githubStack: false # Sync native GitHub Stack metadata for eligible linear PR chains
 #   web: never # Open in browser: always, created, never
 #   labels: [] # Default labels
 #   reviewers: [] # Default reviewers

--- a/internal/github/stacks.go
+++ b/internal/github/stacks.go
@@ -7,9 +7,14 @@ import (
 	"slices"
 )
 
-// MaxStackPullRequests is GitHub's maximum number of pull requests in one
-// native Stack.
-const MaxStackPullRequests = 100
+const (
+	// MinStackPullRequests is GitHub's minimum number of pull requests in one
+	// native Stack.
+	MinStackPullRequests = 2
+	// MaxStackPullRequests is GitHub's maximum number of pull requests in one
+	// native Stack.
+	MaxStackPullRequests = 100
+)
 
 // StackClient is the narrow GitHub Stacks API surface used by the experimental
 // Stackit command. It is deliberately separate from Client while the feature
@@ -90,7 +95,7 @@ func EnsureStack(ctx context.Context, client StackClient, pullRequests []int) (*
 // ValidateStackPullRequestCount validates the GitHub Stacks API's request
 // bounds before a caller performs any irreversible PR writes.
 func ValidateStackPullRequestCount(count int) error {
-	if count < 2 {
+	if count < MinStackPullRequests {
 		return fmt.Errorf("a GitHub Stack requires at least two pull requests")
 	}
 	if count > MaxStackPullRequests {

--- a/internal/github/stacks.go
+++ b/internal/github/stacks.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 )
+
+// MaxStackPullRequests is GitHub's maximum number of pull requests in one
+// native Stack.
+const MaxStackPullRequests = 100
 
 // StackClient is the narrow GitHub Stacks API surface used by the experimental
 // Stackit command. It is deliberately separate from Client while the feature
 // is being evaluated, so normal PR operations do not depend on the API.
 type StackClient interface {
 	CreateStack(ctx context.Context, pullRequests []int) (*StackInfo, error)
+	FindStackByPullRequest(ctx context.Context, pullRequest int) (*StackInfo, error)
+	AddPullRequestsToStack(ctx context.Context, stackNumber int, pullRequests []int) (*StackInfo, error)
 }
 
 // StackInfo is GitHub's server-side representation of a linear stack of pull
@@ -42,12 +49,62 @@ type createStackRequest struct {
 	PullRequests []int `json:"pull_requests"`
 }
 
+// StackSyncAction describes how EnsureStack reconciled native Stack metadata.
+type StackSyncAction string
+
+const (
+	StackSyncCreated   StackSyncAction = "created"
+	StackSyncExtended  StackSyncAction = "extended"
+	StackSyncUnchanged StackSyncAction = "unchanged"
+)
+
+// EnsureStack creates, extends, or leaves unchanged the native GitHub Stack
+// containing the supplied bottom-to-top PR chain. Existing stacks may only be
+// extended at the top; a divergent chain needs explicit user resolution.
+func EnsureStack(ctx context.Context, client StackClient, pullRequests []int) (*StackInfo, StackSyncAction, error) {
+	if err := ValidateStackPullRequestCount(len(pullRequests)); err != nil {
+		return nil, "", err
+	}
+
+	existing, err := client.FindStackByPullRequest(ctx, pullRequests[0])
+	if err != nil {
+		return nil, "", err
+	}
+	if existing == nil {
+		stack, err := client.CreateStack(ctx, pullRequests)
+		return stack, StackSyncCreated, err
+	}
+
+	existingPRs := stackPullRequestNumbers(existing)
+	if slices.Equal(existingPRs, pullRequests) || hasPrefix(existingPRs, pullRequests) {
+		return existing, StackSyncUnchanged, nil
+	}
+	if hasPrefix(pullRequests, existingPRs) {
+		stack, err := client.AddPullRequestsToStack(ctx, existing.Number, pullRequests[len(existingPRs):])
+		return stack, StackSyncExtended, err
+	}
+
+	return nil, "", fmt.Errorf("GitHub Stack #%d has PRs %v, which do not match the submitted chain %v", existing.Number, existingPRs, pullRequests)
+}
+
+// ValidateStackPullRequestCount validates the GitHub Stacks API's request
+// bounds before a caller performs any irreversible PR writes.
+func ValidateStackPullRequestCount(count int) error {
+	if count < 2 {
+		return fmt.Errorf("a GitHub Stack requires at least two pull requests")
+	}
+	if count > MaxStackPullRequests {
+		return fmt.Errorf("a GitHub Stack supports at most %d pull requests (got %d)", MaxStackPullRequests, count)
+	}
+	return nil
+}
+
 // CreateStack creates a native GitHub Stack from the supplied pull request
 // numbers, ordered from bottom to top. GitHub validates that their base refs
 // form a contiguous linear chain.
 func (c *StackitGitHubClient) CreateStack(ctx context.Context, pullRequests []int) (*StackInfo, error) {
-	if len(pullRequests) < 2 {
-		return nil, fmt.Errorf("a GitHub Stack requires at least two pull requests")
+	if err := ValidateStackPullRequestCount(len(pullRequests)); err != nil {
+		return nil, err
 	}
 
 	path := fmt.Sprintf("repos/%s/%s/stacks", c.repo.Owner, c.repo.Name)
@@ -61,6 +118,57 @@ func (c *StackitGitHubClient) CreateStack(ctx context.Context, pullRequests []in
 		return nil, fmt.Errorf("create GitHub Stack: %w", err)
 	}
 	return &stack, nil
+}
+
+// FindStackByPullRequest returns the native Stack containing pullRequest, if
+// it belongs to one.
+func (c *StackitGitHubClient) FindStackByPullRequest(ctx context.Context, pullRequest int) (*StackInfo, error) {
+	path := fmt.Sprintf("repos/%s/%s/stacks?pull_request=%d", c.repo.Owner, c.repo.Name, pullRequest)
+	req, err := c.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build GitHub Stack lookup request: %w", err)
+	}
+
+	var stacks []StackInfo
+	if _, err := c.client.Do(req, &stacks); err != nil {
+		return nil, fmt.Errorf("find GitHub Stack for pull request %d: %w", pullRequest, err)
+	}
+	if len(stacks) == 0 {
+		return nil, nil
+	}
+	return &stacks[0], nil
+}
+
+// AddPullRequestsToStack appends pull requests to the top of an existing
+// native Stack. The PRs must be ordered from the current top upward.
+func (c *StackitGitHubClient) AddPullRequestsToStack(ctx context.Context, stackNumber int, pullRequests []int) (*StackInfo, error) {
+	if len(pullRequests) == 0 {
+		return nil, fmt.Errorf("at least one pull request is required to extend a GitHub Stack")
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/stacks/%d/add", c.repo.Owner, c.repo.Name, stackNumber)
+	req, err := c.client.NewRequest(ctx, http.MethodPost, path, createStackRequest{PullRequests: pullRequests})
+	if err != nil {
+		return nil, fmt.Errorf("build GitHub Stack extension request: %w", err)
+	}
+
+	var stack StackInfo
+	if _, err := c.client.Do(req, &stack); err != nil {
+		return nil, fmt.Errorf("extend GitHub Stack #%d: %w", stackNumber, err)
+	}
+	return &stack, nil
+}
+
+func stackPullRequestNumbers(stack *StackInfo) []int {
+	numbers := make([]int, len(stack.PullRequests))
+	for i, pullRequest := range stack.PullRequests {
+		numbers[i] = pullRequest.Number
+	}
+	return numbers
+}
+
+func hasPrefix(values, prefix []int) bool {
+	return len(values) >= len(prefix) && slices.Equal(values[:len(prefix)], prefix)
 }
 
 var _ StackClient = (*StackitGitHubClient)(nil)

--- a/internal/github/stacks.go
+++ b/internal/github/stacks.go
@@ -1,0 +1,66 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// StackClient is the narrow GitHub Stacks API surface used by the experimental
+// Stackit command. It is deliberately separate from Client while the feature
+// is being evaluated, so normal PR operations do not depend on the API.
+type StackClient interface {
+	CreateStack(ctx context.Context, pullRequests []int) (*StackInfo, error)
+}
+
+// StackInfo is GitHub's server-side representation of a linear stack of pull
+// requests. PullRequests are ordered from the bottom of the stack to the top.
+type StackInfo struct {
+	ID           int           `json:"id"`
+	Number       int           `json:"number"`
+	URL          string        `json:"url"`
+	Base         StackBase     `json:"base"`
+	PullRequests []StackPRInfo `json:"pull_requests"`
+}
+
+// StackBase is the ultimate base branch shared by the GitHub Stack.
+type StackBase struct {
+	Ref string `json:"ref"`
+}
+
+// StackPRInfo is the minimal pull request representation returned by GitHub's
+// Stacks API.
+type StackPRInfo struct {
+	Number int `json:"number"`
+	Head   struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+type createStackRequest struct {
+	PullRequests []int `json:"pull_requests"`
+}
+
+// CreateStack creates a native GitHub Stack from the supplied pull request
+// numbers, ordered from bottom to top. GitHub validates that their base refs
+// form a contiguous linear chain.
+func (c *StackitGitHubClient) CreateStack(ctx context.Context, pullRequests []int) (*StackInfo, error) {
+	if len(pullRequests) < 2 {
+		return nil, fmt.Errorf("a GitHub Stack requires at least two pull requests")
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/stacks", c.repo.Owner, c.repo.Name)
+	req, err := c.client.NewRequest(ctx, http.MethodPost, path, createStackRequest{PullRequests: pullRequests})
+	if err != nil {
+		return nil, fmt.Errorf("build GitHub Stack request: %w", err)
+	}
+
+	var stack StackInfo
+	if _, err := c.client.Do(req, &stack); err != nil {
+		return nil, fmt.Errorf("create GitHub Stack: %w", err)
+	}
+	return &stack, nil
+}
+
+var _ StackClient = (*StackitGitHubClient)(nil)

--- a/internal/github/stacks_test.go
+++ b/internal/github/stacks_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-github/v90/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateStack(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/repos/acme/widget/stacks", r.URL.Path)
+
+		var body createStackRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, []int{12, 34}, body.PullRequests)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id": 99, "number": 7, "url": "https://api.github.com/repos/acme/widget/stacks/7", "base": {"ref": "main"}, "pull_requests": [{"number": 12}, {"number": 34}]}`))
+	}))
+	defer server.Close()
+
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithHTTPClient(server.Client()), github.WithURLs(&baseURL, &baseURL))
+	require.NoError(t, err)
+	stackClient := &StackitGitHubClient{client: client, repo: Repo{Owner: "acme", Name: "widget"}}
+
+	stack, err := stackClient.CreateStack(context.Background(), []int{12, 34})
+	require.NoError(t, err)
+	require.Equal(t, 7, stack.Number)
+	require.Equal(t, "main", stack.Base.Ref)
+	require.Len(t, stack.PullRequests, 2)
+}
+
+func TestCreateStackRequiresTwoPullRequests(t *testing.T) {
+	t.Parallel()
+
+	stackClient := &StackitGitHubClient{}
+	_, err := stackClient.CreateStack(context.Background(), []int{12})
+	require.EqualError(t, err, "a GitHub Stack requires at least two pull requests")
+}

--- a/internal/github/stacks_test.go
+++ b/internal/github/stacks_test.go
@@ -47,3 +47,65 @@ func TestCreateStackRequiresTwoPullRequests(t *testing.T) {
 	_, err := stackClient.CreateStack(context.Background(), []int{12})
 	require.EqualError(t, err, "a GitHub Stack requires at least two pull requests")
 }
+
+func TestCreateStackRejectsMoreThanOneHundredPullRequests(t *testing.T) {
+	t.Parallel()
+
+	stackClient := &StackitGitHubClient{}
+	_, err := stackClient.CreateStack(context.Background(), make([]int, MaxStackPullRequests+1))
+	require.EqualError(t, err, "a GitHub Stack supports at most 100 pull requests (got 101)")
+}
+
+func TestEnsureStackExtendsExistingStack(t *testing.T) {
+	t.Parallel()
+
+	var addRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/stacks":
+			require.Equal(t, "12", r.URL.Query().Get("pull_request"))
+			_, _ = w.Write([]byte(`[{"number": 7, "pull_requests": [{"number": 12}, {"number": 34}]}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/stacks/7/add":
+			addRequests++
+			var body createStackRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Equal(t, []int{56}, body.PullRequests)
+			_, _ = w.Write([]byte(`{"number": 7, "pull_requests": [{"number": 12}, {"number": 34}, {"number": 56}]}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL)
+		}
+	}))
+	defer server.Close()
+
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithHTTPClient(server.Client()), github.WithURLs(&baseURL, &baseURL))
+	require.NoError(t, err)
+	stackClient := &StackitGitHubClient{client: client, repo: Repo{Owner: "acme", Name: "widget"}}
+
+	stack, action, err := EnsureStack(context.Background(), stackClient, []int{12, 34, 56})
+	require.NoError(t, err)
+	require.Equal(t, StackSyncExtended, action)
+	require.Equal(t, 7, stack.Number)
+	require.Equal(t, 1, addRequests)
+}
+
+func TestEnsureStackSkipsMatchingExistingStack(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/repos/acme/widget/stacks", r.URL.Path)
+		_, _ = w.Write([]byte(`[{"number": 7, "pull_requests": [{"number": 12}, {"number": 34}]}]`))
+	}))
+	defer server.Close()
+
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithHTTPClient(server.Client()), github.WithURLs(&baseURL, &baseURL))
+	require.NoError(t, err)
+	stackClient := &StackitGitHubClient{client: client, repo: Repo{Owner: "acme", Name: "widget"}}
+
+	stack, action, err := EnsureStack(context.Background(), stackClient, []int{12, 34})
+	require.NoError(t, err)
+	require.Equal(t, StackSyncUnchanged, action)
+	require.Equal(t, 7, stack.Number)
+}

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -28,7 +28,7 @@ func TUIAction(repoRoot string) error {
 		// Get current values
 		branchPattern := cfg.BranchNamePattern()
 		submitFooter := cfg.SubmitFooter()
-		submitGitHubStack := cfg.SubmitGitHubStack()
+		githubStack := cfg.GitHubStack()
 		mergeMethod := cfg.MergeMethod()
 		if mergeMethod == "" {
 			mergeMethod = "(not set)"
@@ -51,8 +51,8 @@ func TUIAction(repoRoot string) error {
 				Value: "submit.footer",
 			},
 			{
-				Label: fmt.Sprintf("submit.githubStack: %v", submitGitHubStack),
-				Value: "submit.githubStack",
+				Label: fmt.Sprintf("github.stack: %v", githubStack),
+				Value: "github.stack",
 			},
 			{
 				Label: fmt.Sprintf("merge.method: %s", mergeMethod),
@@ -124,20 +124,20 @@ func TUIAction(repoRoot string) error {
 				out.Info("Set submit.footer to: %v", newValue)
 			}
 
-		case "submit.githubStack":
-			newValue, err := tui.PromptConfirm(fmt.Sprintf("Sync native GitHub Stack metadata for eligible linear submits? (current: %v):", submitGitHubStack), submitGitHubStack)
+		case "github.stack":
+			newValue, err := tui.PromptConfirm(fmt.Sprintf("Sync native GitHub Stack metadata for eligible linear submits? (current: %v):", githubStack), githubStack)
 			if err != nil {
 				if errors.Is(err, tui.ErrInteractiveDisabled) || strings.Contains(err.Error(), "canceled") {
 					continue
 				}
 				return err
 			}
-			if newValue != submitGitHubStack {
-				if err := cfg.SetSubmitGitHubStack(newValue); err != nil {
+			if newValue != githubStack {
+				if err := cfg.SetGitHubStack(newValue); err != nil {
 					out.Info("Failed to save config: %v", err)
 					continue
 				}
-				out.Info("Set submit.githubStack to: %v", newValue)
+				out.Info("Set github.stack to: %v", newValue)
 			}
 
 		case "merge.method":

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -28,6 +28,7 @@ func TUIAction(repoRoot string) error {
 		// Get current values
 		branchPattern := cfg.BranchNamePattern()
 		submitFooter := cfg.SubmitFooter()
+		submitGitHubStack := cfg.SubmitGitHubStack()
 		mergeMethod := cfg.MergeMethod()
 		if mergeMethod == "" {
 			mergeMethod = "(not set)"
@@ -48,6 +49,10 @@ func TUIAction(repoRoot string) error {
 			{
 				Label: fmt.Sprintf("submit.footer: %v", submitFooter),
 				Value: "submit.footer",
+			},
+			{
+				Label: fmt.Sprintf("submit.githubStack: %v", submitGitHubStack),
+				Value: "submit.githubStack",
 			},
 			{
 				Label: fmt.Sprintf("merge.method: %s", mergeMethod),
@@ -117,6 +122,22 @@ func TUIAction(repoRoot string) error {
 					continue
 				}
 				out.Info("Set submit.footer to: %v", newValue)
+			}
+
+		case "submit.githubStack":
+			newValue, err := tui.PromptConfirm(fmt.Sprintf("Sync native GitHub Stack metadata for eligible linear submits? (current: %v):", submitGitHubStack), submitGitHubStack)
+			if err != nil {
+				if errors.Is(err, tui.ErrInteractiveDisabled) || strings.Contains(err.Error(), "canceled") {
+					continue
+				}
+				return err
+			}
+			if newValue != submitGitHubStack {
+				if err := cfg.SetSubmitGitHubStack(newValue); err != nil {
+					out.Info("Failed to save config: %v", err)
+					continue
+				}
+				out.Info("Set submit.githubStack to: %v", newValue)
 			}
 
 		case "merge.method":

--- a/testhelpers/github_mock.go
+++ b/testhelpers/github_mock.go
@@ -21,6 +21,8 @@ type MockGitHubServerConfig struct {
 	CreatedPRs []*github.PullRequest
 	// UpdatedPRs stores PRs that were updated (for testing)
 	UpdatedPRs map[int]*github.PullRequest
+	// CreatedStacks records the PR numbers submitted as native GitHub Stacks.
+	CreatedStacks [][]int
 	// ErrorResponses maps endpoint+method to error responses
 	ErrorResponses map[string]error
 	// Owner and Repo for the mock server
@@ -36,6 +38,7 @@ func NewMockGitHubServerConfig() *MockGitHubServerConfig {
 		PRs:            make(map[string]*github.PullRequest),
 		CreatedPRs:     make([]*github.PullRequest, 0),
 		UpdatedPRs:     make(map[int]*github.PullRequest),
+		CreatedStacks:  make([][]int, 0),
 		ErrorResponses: make(map[string]error),
 		Owner:          "owner",
 		Repo:           "repo",

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -42,7 +42,49 @@ func (c *MockGitHubClient) CreateStack(_ context.Context, pullRequests []int) (*
 
 	created := append([]int(nil), pullRequests...)
 	c.config.CreatedStacks = append(c.config.CreatedStacks, created)
-	return &githubpkg.StackInfo{Number: len(c.config.CreatedStacks), PullRequests: make([]githubpkg.StackPRInfo, len(created))}, nil
+	return mockStackInfo(len(c.config.CreatedStacks), created), nil
+}
+
+// FindStackByPullRequest returns the mock native Stack containing pullRequest.
+func (c *MockGitHubClient) FindStackByPullRequest(_ context.Context, pullRequest int) (*githubpkg.StackInfo, error) {
+	c.config.mu.Lock()
+	defer c.config.mu.Unlock()
+
+	for i, stack := range c.config.CreatedStacks {
+		if containsInt(stack, pullRequest) {
+			return mockStackInfo(i+1, stack), nil
+		}
+	}
+	return nil, nil
+}
+
+// AddPullRequestsToStack extends a mock native Stack in place.
+func (c *MockGitHubClient) AddPullRequestsToStack(_ context.Context, stackNumber int, pullRequests []int) (*githubpkg.StackInfo, error) {
+	c.config.mu.Lock()
+	defer c.config.mu.Unlock()
+
+	if stackNumber < 1 || stackNumber > len(c.config.CreatedStacks) {
+		return nil, fmt.Errorf("GitHub Stack #%d does not exist", stackNumber)
+	}
+	c.config.CreatedStacks[stackNumber-1] = append(c.config.CreatedStacks[stackNumber-1], pullRequests...)
+	return mockStackInfo(stackNumber, c.config.CreatedStacks[stackNumber-1]), nil
+}
+
+func mockStackInfo(number int, pullRequests []int) *githubpkg.StackInfo {
+	stack := &githubpkg.StackInfo{Number: number, PullRequests: make([]githubpkg.StackPRInfo, len(pullRequests))}
+	for i, pullRequest := range pullRequests {
+		stack.PullRequests[i].Number = pullRequest
+	}
+	return stack
+}
+
+func containsInt(values []int, target int) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 // CreatePullRequest creates a new pull request

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -35,6 +35,16 @@ func (c *MockGitHubClient) Repo() githubpkg.Repo {
 	return githubpkg.Repo{Owner: c.owner, Name: c.repo}
 }
 
+// CreateStack records native GitHub Stack creation for submit integration tests.
+func (c *MockGitHubClient) CreateStack(_ context.Context, pullRequests []int) (*githubpkg.StackInfo, error) {
+	c.config.mu.Lock()
+	defer c.config.mu.Unlock()
+
+	created := append([]int(nil), pullRequests...)
+	c.config.CreatedStacks = append(c.config.CreatedStacks, created)
+	return &githubpkg.StackInfo{Number: len(c.config.CreatedStacks), PullRequests: make([]githubpkg.StackPRInfo, len(created))}, nil
+}
+
 // CreatePullRequest creates a new pull request
 func (c *MockGitHubClient) CreatePullRequest(ctx context.Context, opts githubpkg.CreatePROptions) (*githubpkg.PullRequestInfo, error) {
 	pr := github.CreatePullRequest{


### PR DESCRIPTION
This PR merges the following changes:

1. **#1541** feat(github): add native stack creation probe
2. **#1558** fix(github): reconcile native Stack submissions
3. **#1559** feat(submit): opt into native GitHub Stack sync
4. **#1560** refactor(config): group GitHub settings under github

### Stack

```
main
  └─ jonnii/20260731022328/add-native-stack-creation-probe (#1541)
    └─ jonnii/20260801153717/reconcile-native-Stack-submissions (#1558)
      └─ jonnii/20260801161353/opt-into-native-GitHub-Stack-sync (#1559)
        └─ jonnii/20260801180237/group-GitHub-settings-under-github (#1560)
```

Stackit-Stack-Size: 4
Stackit-PRs: 1541,1558,1559,1560
