### PR TITLE
refactor(navigation): deduplicate flattenThroughAnchors

### DIFF
--- a/internal/actions/navigation/action.go
+++ b/internal/actions/navigation/action.go
@@ -103,7 +103,7 @@ func traverseUpward(currentBranch string, ctx *app.Context, graph *engine.StackG
 	children := graph.ChildBranches(ctx.Engine.GetBranch(currentBranch))
 
 	// Filter out worktree anchors, but include their children
-	children = flattenThroughAnchors(children, graph)
+	children = FlattenThroughAnchors(children, graph)
 
 	if len(children) == 0 {
 		// No children, we're at the tip
@@ -128,19 +128,22 @@ func traverseUpward(currentBranch string, ctx *app.Context, graph *engine.StackG
 	return traverseUpward(nextBranch, ctx, graph, handler)
 }
 
-// flattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
-func flattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
-	result := engine.Branches{}
+// FlattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
+func FlattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
+	builder := engine.NewBranchesBuilder(len(branches))
+	flattenThroughAnchorsInto(builder, branches, graph)
+	return builder.Build()
+}
+
+func flattenThroughAnchorsInto(builder *engine.BranchesBuilder, branches engine.Branches, graph *engine.StackGraph) {
 	for _, b := range branches {
 		if b.IsWorktreeAnchor() {
 			// Replace anchor with its children (recursively flatten)
-			grandchildren := graph.ChildBranches(b)
-			result = result.Concat(flattenThroughAnchors(grandchildren, graph))
-		} else {
-			result = result.Append(b)
+			flattenThroughAnchorsInto(builder, graph.ChildBranches(b), graph)
+			continue
 		}
+		builder.Add(b)
 	}
-	return result
 }
 
 // handleMultipleChildren prompts the user to select a branch when multiple children exist

--- a/internal/actions/navigation/action_test.go
+++ b/internal/actions/navigation/action_test.go
@@ -164,7 +164,7 @@ func TestFlattenThroughAnchorsPromotesGrandchildren(t *testing.T) {
 	t.Parallel()
 
 	// Stack: main -> anchor -> [child1, child2]
-	// flattenThroughAnchors should replace anchor with child1 and child2
+	// FlattenThroughAnchors should replace anchor with child1 and child2
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{
 			"anchor": "main",
@@ -179,7 +179,7 @@ func TestFlattenThroughAnchorsPromotesGrandchildren(t *testing.T) {
 	trunk := s.Engine.Trunk()
 	children := graph.ChildBranches(trunk)
 
-	flattened := flattenThroughAnchors(children, graph)
+	flattened := FlattenThroughAnchors(children, graph)
 	names := make([]string, len(flattened))
 	for i, b := range flattened {
 		names[i] = b.GetName()

--- a/internal/cli/navigation/up.go
+++ b/internal/cli/navigation/up.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/navigation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/engine"
@@ -56,7 +57,7 @@ the --to flag is used to specify a target branch to navigate towards.`,
 				// Traverse up the specified number of steps
 				targetBranch := currentBranch.GetName()
 				for i := 0; i < steps; i++ {
-					children := flattenThroughAnchors(graph.ChildBranches(ctx.Engine.GetBranch(targetBranch)), graph)
+					children := navigation.FlattenThroughAnchors(graph.ChildBranches(ctx.Engine.GetBranch(targetBranch)), graph)
 					if len(children) == 0 {
 						if i == 0 {
 							ctx.Output.Info("Already at the top of the stack.")
@@ -127,20 +128,6 @@ the --to flag is used to specify a target branch to navigate towards.`,
 	_ = cmd.RegisterFlagCompletionFunc("to", common.CompleteBranches)
 
 	return cmd
-}
-
-// flattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
-func flattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
-	result := engine.Branches{}
-	for _, b := range branches {
-		if b.IsWorktreeAnchor() {
-			grandchildren := graph.ChildBranches(b)
-			result = result.Concat(flattenThroughAnchors(grandchildren, graph))
-		} else {
-			result = result.Append(b)
-		}
-	}
-	return result
 }
 
 func promptForChild(children []string, parent string) (string, error) {


### PR DESCRIPTION
## Summary
- `internal/cli/navigation/up.go` carried a byte-for-byte copy of `internal/actions/navigation`'s `flattenThroughAnchors`, differing only by an inline comment. Two copies of worktree-anchor flattening logic can silently drift — only the `actions` copy had test coverage (`action_test.go`).
- Export `FlattenThroughAnchors` from `internal/actions/navigation` (the package `up.go` already sits alongside via other CLI navigation commands, e.g. `top.go`/`bottom.go` already import it) and delete the CLI-local copy.
- While touching it: rewrote the recursive `Concat`/`Append` chain to build through `engine.BranchesBuilder` instead. `Branches.Append`/`Concat` each do a full slice copy + dedup-map rebuild (`NewBranches`) per call, so the old recursive version was O(n²) in the number of anchors/children flattened. The builder accumulates without that per-call rebuild — same dedup-by-name, first-seen-order semantics, just without the repeated copying.

Net effect: one less duplicated implementation, one path gains test coverage it didn't have, and that path is a bit cheaper for stacks with several worktree anchors.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/actions/navigation/... ./internal/cli/navigation/...`
- [x] `go test ./internal/actions/navigation/... ./internal/cli/navigation/...`
- [x] `go test ./internal/actions/... ./internal/cli/...` (full actions/cli suite, to be safe since `up`/`top`/`bottom` all touch this path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1uNgZTwYDTZ7cVGNEMvbr)_