### PR TITLE
fix(submit): make configured GitHub Stack sync best-effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,9 @@ stackit config set github.stack true
 stackit submit
 ```
 
-With this option enabled, submissions containing two or more PRs reconcile GitHub's server-side Stack resource. Single-PR submissions behave normally. Use `stackit submit --with-native-stack` for a one-off sync instead.
+With this option enabled, submissions containing two or more PRs reconcile GitHub's server-side Stack resource. Single-PR submissions behave normally.
+
+Sync configured this way is best-effort: if the stack is not a linear chain, or the Stacks API is unavailable for the repository, `submit` reports the reason and completes normally rather than failing. Use `stackit submit --with-native-stack` for a one-off sync that fails loudly instead.
 
 ---
 

--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -106,6 +106,16 @@ type GitHubStackSyncedEvent struct {
 
 func (GitHubStackSyncedEvent) submitEvent() {}
 
+// GitHubStackSkippedEvent reports that native GitHub Stack sync was enabled by
+// config but did not run, either because the submitted branches are ineligible
+// or because the Stacks API call failed. Configured sync is best-effort so the
+// submit still succeeds; the explicit --with-native-stack flag fails instead.
+type GitHubStackSkippedEvent struct {
+	Reason string
+}
+
+func (GitHubStackSkippedEvent) submitEvent() {}
+
 // CompletionOutcome classifies how a submit run ended, so handlers can decide
 // presentation without string-matching messages.
 type CompletionOutcome string

--- a/internal/actions/submit/json_handler.go
+++ b/internal/actions/submit/json_handler.go
@@ -14,6 +14,8 @@ type JSONResult struct {
 	Error       string                 `json:"error,omitempty"`
 	Branches    []JSONBranchResult     `json:"branches"`
 	GitHubStack *JSONGitHubStackResult `json:"github_stack,omitempty"`
+	// GitHubStackSkipped explains why configured native Stack sync did not run.
+	GitHubStackSkipped string `json:"github_stack_skipped,omitempty"`
 }
 
 // JSONGitHubStackResult identifies native GitHub Stack metadata reconciled by submit.
@@ -100,6 +102,9 @@ func (h *JSONHandler) OnEvent(e Event) {
 
 	case GitHubStackSyncedEvent:
 		h.Result.GitHubStack = &JSONGitHubStackResult{Number: ev.Number, PullRequests: ev.PullRequests, Action: string(ev.Action)}
+
+	case GitHubStackSkippedEvent:
+		h.Result.GitHubStackSkipped = ev.Reason
 
 	case CompletionEvent:
 		h.Result.Outcome = ev.Outcome

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -252,17 +252,25 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// validation can prune stale descendants, so validating earlier could let a
 	// one-PR list perform normal PR writes before native Stack creation fails.
 	if opts.CreateGitHubStack {
-		if !explicitGitHubStack && (len(branchObjs) < github.MinStackPullRequests || len(branchObjs) > github.MaxStackPullRequests) {
+		countErr := github.ValidateStackPullRequestCount(len(branchObjs))
+		switch {
+		case countErr != nil && explicitGitHubStack:
+			return countErr
+		case countErr != nil:
+			// A submit that isn't stack-shaped (commonly a single branch) is the
+			// ordinary case when sync is configured, so skip it quietly.
 			opts.CreateGitHubStack = false
-		} else {
-			if ctx.Config == nil || ctx.Config.StackShape() != config.StackShapeLinear {
-				return fmt.Errorf("native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
-			}
-			if err := validateGitHubStackChain(eng, branchObjs); err != nil {
-				return err
-			}
-			if err := github.ValidateStackPullRequestCount(len(branchObjs)); err != nil {
-				return err
+		default:
+			if err := validateGitHubStackShape(ctx, eng, branchObjs); err != nil {
+				if explicitGitHubStack {
+					return err
+				}
+				// Configured sync is best-effort. Failing here would break every
+				// multi-branch submit for a team whose .stackit.yaml enables the
+				// key without stack.shape=linear, including submits nested inside
+				// merge and lock.
+				opts.CreateGitHubStack = false
+				handler.OnEvent(GitHubStackSkippedEvent{Reason: err.Error()})
 			}
 		}
 	}
@@ -292,8 +300,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if len(submissionInfos) == 0 {
 		if opts.CreateGitHubStack {
 			if err := publishGitHubStackMetadata(ctx, branchObjs, handler); err != nil {
-				handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
-				return fmt.Errorf("PRs are already up to date, but creating native GitHub Stack metadata failed: %w", err)
+				if explicitGitHubStack {
+					handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+					return fmt.Errorf("PRs are already up to date, but creating native GitHub Stack metadata failed: %w", err)
+				}
+				handler.OnEvent(GitHubStackSkippedEvent{Reason: err.Error()})
+				handler.OnEvent(CompletionEvent{Outcome: OutcomeUpToDate, Message: "All PRs up to date"})
+				return nil
 			}
 			handler.OnEvent(CompletionEvent{Outcome: OutcomeComplete, Message: "GitHub Stack metadata submitted", Duration: time.Since(start)})
 			return nil
@@ -428,8 +441,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	if opts.CreateGitHubStack {
 		if err := publishGitHubStackMetadata(ctx, branchObjs, handler); err != nil {
-			handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
-			return fmt.Errorf("PRs were submitted successfully, but creating native GitHub Stack metadata failed: %w", err)
+			if explicitGitHubStack {
+				handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+				return fmt.Errorf("PRs were submitted successfully, but creating native GitHub Stack metadata failed: %w", err)
+			}
+			// Every PR already landed. Reporting the run as failed would exit
+			// non-zero on work that fully succeeded, so surface the Stacks API
+			// problem as a warning instead.
+			handler.OnEvent(GitHubStackSkippedEvent{Reason: err.Error()})
 		}
 	}
 
@@ -446,6 +465,15 @@ func publishGitHubStackMetadata(ctx *app.Context, branches engine.Branches, hand
 	}
 	handler.OnEvent(GitHubStackSyncedEvent{Number: stack.Number, PullRequests: pullRequests, Action: action})
 	return nil
+}
+
+// validateGitHubStackShape reports why the submitted branches cannot form a
+// native GitHub Stack, beyond the pull request count checked by the caller.
+func validateGitHubStackShape(ctx *app.Context, eng engine.Engine, branches engine.Branches) error {
+	if ctx.Config == nil || ctx.Config.StackShape() != config.StackShapeLinear {
+		return fmt.Errorf("native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
+	}
+	return validateGitHubStackChain(eng, branches)
 }
 
 func validateGitHubStackChain(eng engine.Engine, branches engine.Branches) error {

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -823,3 +823,128 @@ func TestSubmitDisplayTreeSkipsWorktreeAnchorParent(t *testing.T) {
 	_, hasAnchorFixedState := stack.FixedMap["wt-anchor"]
 	require.False(t, hasAnchorFixedState, "fixed map should not include non-submittable worktree anchors")
 }
+
+// captureSkipHandler records native GitHub Stack skip reasons and the final outcome.
+type captureSkipHandler struct {
+	reasons []string
+	outcome submit.CompletionOutcome
+}
+
+func (h *captureSkipHandler) OnEvent(e submit.Event) {
+	switch ev := e.(type) {
+	case submit.GitHubStackSkippedEvent:
+		h.reasons = append(h.reasons, ev.Reason)
+	case submit.CompletionEvent:
+		h.outcome = ev.Outcome
+	}
+}
+func (h *captureSkipHandler) Confirm(_ string, defaultYes bool) (bool, error) { return defaultYes, nil }
+func (h *captureSkipHandler) IsInteractive() bool                             { return false }
+
+// Configured sync is best-effort: a team whose .stackit.yaml enables github.stack
+// without stack.shape=linear must still be able to submit. Only the explicit
+// --with-native-stack flag hard-fails (TestSubmitGitHubStackRequiresLinearMode).
+func TestSubmitConfiguredGitHubStackSkipsNonLinearShape(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetGitHubStack(true)) // stack.shape stays the default "tree"
+	s.Context.Config = cfg
+
+	s.Checkout("api")
+	handler := &captureSkipHandler{}
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, handler)
+	require.NoError(t, err, "configured sync must not fail a submit on a tree-shaped stack")
+	require.Len(t, mockConfig.CreatedPRs, 2, "both PRs should still submit")
+	require.Empty(t, mockConfig.CreatedStacks, "native Stack metadata must be skipped")
+	require.Equal(t, submit.OutcomeComplete, handler.outcome)
+	require.Contains(t, handler.reasons, "native GitHub Stack creation requires stack.shape=linear; run 'stackit config set stack.shape linear'")
+}
+
+// A forked chain is likewise a skip, not a failure, when sync came from config.
+func TestSubmitConfiguredGitHubStackSkipsForkedChain(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base", "ui": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	require.NoError(t, cfg.SetGitHubStack(true))
+	s.Context.Config = cfg
+
+	s.Checkout("base")
+	handler := &captureSkipHandler{}
+	err = submit.Action(s.Context, submit.Options{StackRange: engine.StackRangeFull(), NoEdit: true, Draft: true}, handler)
+	require.NoError(t, err, "configured sync must not fail a submit on a pre-existing fork")
+	require.Empty(t, mockConfig.CreatedStacks)
+	require.Contains(t, handler.reasons, "branch \"base\" forks to api, ui; native GitHub Stacks require a linear chain")
+}
+
+// A repo without access to the experimental Stacks API must not turn a submit
+// whose PRs all landed into a non-zero exit.
+func TestSubmitConfiguredGitHubStackWarnsWhenStacksAPIFails(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	mockConfig.StackError = fmt.Errorf("stacks API unavailable")
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	require.NoError(t, cfg.SetGitHubStack(true))
+	s.Context.Config = cfg
+
+	s.Checkout("api")
+	handler := &captureSkipHandler{}
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, handler)
+	require.NoError(t, err, "PRs landed, so the run must not report failure")
+	require.Len(t, mockConfig.CreatedPRs, 2)
+	require.Equal(t, submit.OutcomeComplete, handler.outcome)
+	require.Len(t, handler.reasons, 1)
+	require.Contains(t, handler.reasons[0], "stacks API unavailable")
+}
+
+// The explicit flag keeps the strict contract: a Stacks API failure fails the run.
+func TestSubmitExplicitGitHubStackFailsWhenStacksAPIFails(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	mockConfig.StackError = fmt.Errorf("stacks API unavailable")
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	s.Checkout("api")
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
+	require.ErrorContains(t, err, "creating native GitHub Stack metadata failed")
+}

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -469,6 +469,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 	case submit.GitHubStackSyncedEvent:
 		h.Output.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(ev.Action), ev.Number, formatGitHubStackPRs(ev.PullRequests))
 
+	case submit.GitHubStackSkippedEvent:
+		h.Output.Warn("Skipped native GitHub Stack sync: %s", ev.Reason)
+
 	case submit.CompletionEvent:
 		h.plan.Flush()
 		switch ev.Outcome {
@@ -581,12 +584,13 @@ func (h *SimpleSubmitHandler) Confirm(_ string, defaultYes bool) (bool, error) {
 
 // InteractiveSubmitHandler implements submit.Handler with bubbletea for animated progress
 type InteractiveSubmitHandler struct {
-	runner        *tui.Runner
-	model         *submitComponent.Model
-	out           output.Output
-	plan          planPrinter
-	inSubmitPhase bool
-	githubStack   *submit.GitHubStackSyncedEvent
+	runner             *tui.Runner
+	model              *submitComponent.Model
+	out                output.Output
+	plan               planPrinter
+	inSubmitPhase      bool
+	githubStack        *submit.GitHubStackSyncedEvent
+	githubStackSkipped string
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
@@ -672,6 +676,13 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		}
 		h.out.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(ev.Action), ev.Number, formatGitHubStackPRs(ev.PullRequests))
 
+	case submit.GitHubStackSkippedEvent:
+		if h.runner.IsRunning() {
+			h.githubStackSkipped = ev.Reason
+			return
+		}
+		h.out.Warn("Skipped native GitHub Stack sync: %s", ev.Reason)
+
 	case submit.CompletionEvent:
 		h.plan.Flush()
 		// If the submission phase never started (nothing to submit, dry run,
@@ -695,6 +706,9 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		h.runner.Wait()
 		if h.githubStack != nil {
 			h.out.Success("%s native GitHub Stack #%d from %s.", githubStackActionLabel(h.githubStack.Action), h.githubStack.Number, formatGitHubStackPRs(h.githubStack.PullRequests))
+		}
+		if h.githubStackSkipped != "" {
+			h.out.Warn("Skipped native GitHub Stack sync: %s", h.githubStackSkipped)
 		}
 	}
 }

--- a/testhelpers/github_mock.go
+++ b/testhelpers/github_mock.go
@@ -23,6 +23,9 @@ type MockGitHubServerConfig struct {
 	UpdatedPRs map[int]*github.PullRequest
 	// CreatedStacks records the PR numbers submitted as native GitHub Stacks.
 	CreatedStacks [][]int
+	// StackError, when set, is returned by every native GitHub Stacks API call.
+	// Repos without access to the experimental API fail this way.
+	StackError error
 	// ErrorResponses maps endpoint+method to error responses
 	ErrorResponses map[string]error
 	// Owner and Repo for the mock server

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -40,6 +40,9 @@ func (c *MockGitHubClient) CreateStack(_ context.Context, pullRequests []int) (*
 	c.config.mu.Lock()
 	defer c.config.mu.Unlock()
 
+	if c.config.StackError != nil {
+		return nil, c.config.StackError
+	}
 	created := append([]int(nil), pullRequests...)
 	c.config.CreatedStacks = append(c.config.CreatedStacks, created)
 	return mockStackInfo(len(c.config.CreatedStacks), created), nil
@@ -50,6 +53,9 @@ func (c *MockGitHubClient) FindStackByPullRequest(_ context.Context, pullRequest
 	c.config.mu.Lock()
 	defer c.config.mu.Unlock()
 
+	if c.config.StackError != nil {
+		return nil, c.config.StackError
+	}
 	for i, stack := range c.config.CreatedStacks {
 		if containsInt(stack, pullRequest) {
 			return mockStackInfo(i+1, stack), nil


### PR DESCRIPTION

Enabling native Stack sync through config turned two ineligibility cases
into hard failures. A non-linear stack shape or a pre-existing fork
aborted the whole submit, and because enablement is inherited from
ctx.Config, that also broke the submits nested inside merge drain and
lock. A team that put github.stack in .stackit.yaml without also setting
stack.shape=linear could not submit at all.

Separately, a Stacks API error after every PR had already been created
reported the run as failed and exited non-zero on work that fully
landed — the realistic trigger being a repo without access to the
experimental API.

Configured sync now skips with a reported reason in both cases; the
explicit --with-native-stack flag keeps the strict contract. The branch
count check stays silent since a single-branch submit is the ordinary
case, not a problem worth warning about.