### PR TITLE
fix(submit): require a contiguous chain for native GitHub Stack sync

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -476,12 +476,28 @@ func validateGitHubStackShape(ctx *app.Context, eng engine.Engine, branches engi
 	return validateGitHubStackChain(eng, branches)
 }
 
+// validateGitHubStackChain requires the submitted branches to form one
+// contiguous chain, each stacked directly on the one before it. Branches arrive
+// bottom-to-top from StackGraph.Range.
+//
+// Checking only that no branch forks is not enough. Trunk is excluded from the
+// submitted set, so several independent stacks rooted at trunk each satisfy a
+// per-branch fork check while together forming no chain at all — which is what
+// `submit --stack` from trunk selects. GitHub rejects that set with "Pull
+// requests must form a stack", so catch it here before any PR writes.
 func validateGitHubStackChain(eng engine.Engine, branches engine.Branches) error {
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
-	for _, branch := range branches {
-		if children := graph.Children(branch); len(children) > 1 {
-			return fmt.Errorf("branch %q forks to %s; native GitHub Stacks require a linear chain", branch.GetName(), strings.Join(children, ", "))
+	trunk := eng.Trunk().GetName()
+	for i := 1; i < len(branches); i++ {
+		parent := graph.Parent(branches[i])
+		previous := branches[i-1].GetName()
+		if parent == previous {
+			continue
 		}
+		if parent == trunk {
+			return fmt.Errorf("branches %q and %q are in different stacks; native GitHub Stacks require a single linear chain", previous, branches[i].GetName())
+		}
+		return fmt.Errorf("branch %q is stacked on %q, not on %q; native GitHub Stacks require a single linear chain", branches[i].GetName(), parent, previous)
 	}
 	return nil
 }

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -510,7 +510,7 @@ func TestSubmitGitHubStackRejectsForkedChain(t *testing.T) {
 	s.Context.Config = cfg
 
 	err = submit.Action(s.Context, submit.Options{StackRange: engine.StackRangeFull(), CreateGitHubStack: true}, &noopHandler{})
-	require.EqualError(t, err, "branch \"base\" forks to api, ui; native GitHub Stacks require a linear chain")
+	require.EqualError(t, err, "branch \"ui\" is stacked on \"base\", not on \"api\"; native GitHub Stacks require a single linear chain")
 }
 
 func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
@@ -893,7 +893,7 @@ func TestSubmitConfiguredGitHubStackSkipsForkedChain(t *testing.T) {
 	err = submit.Action(s.Context, submit.Options{StackRange: engine.StackRangeFull(), NoEdit: true, Draft: true}, handler)
 	require.NoError(t, err, "configured sync must not fail a submit on a pre-existing fork")
 	require.Empty(t, mockConfig.CreatedStacks)
-	require.Contains(t, handler.reasons, "branch \"base\" forks to api, ui; native GitHub Stacks require a linear chain")
+	require.Contains(t, handler.reasons, "branch \"ui\" is stacked on \"base\", not on \"api\"; native GitHub Stacks require a single linear chain")
 }
 
 // A repo without access to the experimental Stacks API must not turn a submit
@@ -947,4 +947,83 @@ func TestSubmitExplicitGitHubStackFailsWhenStacksAPIFails(t *testing.T) {
 	s.Checkout("api")
 	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
 	require.ErrorContains(t, err, "creating native GitHub Stack metadata failed")
+}
+
+// `submit --stack` from trunk selects every branch in the repository. Each
+// independent stack is linear on its own and no branch forks, so a per-branch
+// fork check passes — but the set is not one chain, and GitHub rejects it with
+// "Pull requests must form a stack". Catch it before any PR writes.
+func TestSubmitGitHubStackRejectsDisjointStacksFromTrunk(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"one-bottom": "main",
+			"one-top":    "one-bottom",
+			"two-bottom": "main",
+			"two-top":    "two-bottom",
+		})
+	s.Checkout("main")
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{StackRange: engine.StackRangeFull(), CreateGitHubStack: true}, &noopHandler{})
+	require.EqualError(t, err, "branches \"one-top\" and \"two-bottom\" are in different stacks; native GitHub Stacks require a single linear chain")
+}
+
+// The configured path skips disjoint stacks rather than failing the submit.
+func TestSubmitConfiguredGitHubStackSkipsDisjointStacksFromTrunk(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"one-bottom": "main",
+			"one-top":    "one-bottom",
+			"two-bottom": "main",
+			"two-top":    "two-bottom",
+		})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	require.NoError(t, cfg.SetGitHubStack(true))
+	s.Context.Config = cfg
+
+	s.Checkout("main")
+	handler := &captureSkipHandler{}
+	err = submit.Action(s.Context, submit.Options{StackRange: engine.StackRangeFull(), NoEdit: true, Draft: true}, handler)
+	require.NoError(t, err, "submitting every stack must still succeed")
+	require.Empty(t, mockConfig.CreatedStacks, "disjoint stacks must not create native Stack metadata")
+	require.Contains(t, handler.reasons, "branches \"one-top\" and \"two-bottom\" are in different stacks; native GitHub Stacks require a single linear chain")
+}
+
+// A genuine single chain still syncs.
+func TestSubmitGitHubStackAcceptsContiguousChain(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"bottom": "main", "middle": "bottom", "top": "middle"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	s.Checkout("top")
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedStacks, 1)
+	require.Len(t, mockConfig.CreatedStacks[0], 3, "all three PRs should form one native Stack")
 }


### PR DESCRIPTION

The eligibility check only rejected branches that fork. Trunk is excluded
from the submitted set, so several independent stacks rooted at trunk each
passed a per-branch fork check while together forming no chain at all.
`submit --stack` from trunk selects exactly that set, so it built a payload
spanning every stack in the repository and GitHub rejected it with 422
"Pull requests must form a stack, where each PR's base ref is the previous
PR's head ref".

Validate instead that each branch is stacked directly on the one before it.
The branch list already arrives bottom-to-top from StackGraph.Range, so this
also subsumes the fork case: two children of one parent cannot both follow
it in the sequence.