### PR TITLE
refactor: consolidate duplicated flattenThroughAnchors into StackGraph

### DIFF
--- a/internal/actions/navigation/action.go
+++ b/internal/actions/navigation/action.go
@@ -103,7 +103,7 @@ func traverseUpward(currentBranch string, ctx *app.Context, graph *engine.StackG
 	children := graph.ChildBranches(ctx.Engine.GetBranch(currentBranch))
 
 	// Filter out worktree anchors, but include their children
-	children = flattenThroughAnchors(children, graph)
+	children = graph.FlattenThroughAnchors(children)
 
 	if len(children) == 0 {
 		// No children, we're at the tip
@@ -126,21 +126,6 @@ func traverseUpward(currentBranch string, ctx *app.Context, graph *engine.StackG
 
 	ctx.Output.Info("⮑  %s", nextBranch)
 	return traverseUpward(nextBranch, ctx, graph, handler)
-}
-
-// flattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
-func flattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
-	result := engine.Branches{}
-	for _, b := range branches {
-		if b.IsWorktreeAnchor() {
-			// Replace anchor with its children (recursively flatten)
-			grandchildren := graph.ChildBranches(b)
-			result = result.Concat(flattenThroughAnchors(grandchildren, graph))
-		} else {
-			result = result.Append(b)
-		}
-	}
-	return result
 }
 
 // handleMultipleChildren prompts the user to select a branch when multiple children exist

--- a/internal/actions/navigation/action_test.go
+++ b/internal/actions/navigation/action_test.go
@@ -164,7 +164,7 @@ func TestFlattenThroughAnchorsPromotesGrandchildren(t *testing.T) {
 	t.Parallel()
 
 	// Stack: main -> anchor -> [child1, child2]
-	// flattenThroughAnchors should replace anchor with child1 and child2
+	// FlattenThroughAnchors should replace anchor with child1 and child2
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{
 			"anchor": "main",
@@ -179,7 +179,7 @@ func TestFlattenThroughAnchorsPromotesGrandchildren(t *testing.T) {
 	trunk := s.Engine.Trunk()
 	children := graph.ChildBranches(trunk)
 
-	flattened := flattenThroughAnchors(children, graph)
+	flattened := graph.FlattenThroughAnchors(children)
 	names := make([]string, len(flattened))
 	for i, b := range flattened {
 		names[i] = b.GetName()

--- a/internal/cli/navigation/up.go
+++ b/internal/cli/navigation/up.go
@@ -56,7 +56,7 @@ the --to flag is used to specify a target branch to navigate towards.`,
 				// Traverse up the specified number of steps
 				targetBranch := currentBranch.GetName()
 				for i := 0; i < steps; i++ {
-					children := flattenThroughAnchors(graph.ChildBranches(ctx.Engine.GetBranch(targetBranch)), graph)
+					children := graph.FlattenThroughAnchors(graph.ChildBranches(ctx.Engine.GetBranch(targetBranch)))
 					if len(children) == 0 {
 						if i == 0 {
 							ctx.Output.Info("Already at the top of the stack.")
@@ -127,20 +127,6 @@ the --to flag is used to specify a target branch to navigate towards.`,
 	_ = cmd.RegisterFlagCompletionFunc("to", common.CompleteBranches)
 
 	return cmd
-}
-
-// flattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
-func flattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
-	result := engine.Branches{}
-	for _, b := range branches {
-		if b.IsWorktreeAnchor() {
-			grandchildren := graph.ChildBranches(b)
-			result = result.Concat(flattenThroughAnchors(grandchildren, graph))
-		} else {
-			result = result.Append(b)
-		}
-	}
-	return result
 }
 
 func promptForChild(children []string, parent string) (string, error) {

--- a/internal/engine/stack_graph.go
+++ b/internal/engine/stack_graph.go
@@ -216,6 +216,20 @@ func (g *StackGraph) ChildBranches(branch Branch) Branches {
 	return NewBranches(branches)
 }
 
+// FlattenThroughAnchors replaces worktree anchor branches with their non-anchor
+// children, recursively, so callers see only real (non-anchor) branches.
+func (g *StackGraph) FlattenThroughAnchors(branches Branches) Branches {
+	result := Branches{}
+	for _, b := range branches {
+		if b.IsWorktreeAnchor() {
+			result = result.Concat(g.FlattenThroughAnchors(g.ChildBranches(b)))
+		} else {
+			result = result.Append(b)
+		}
+	}
+	return result
+}
+
 // Parent returns the parent branch name (empty string if none).
 func (g *StackGraph) Parent(branch Branch) string {
 	if node := g.nodes[branch.GetName()]; node != nil {


### PR DESCRIPTION
## Summary
- `flattenThroughAnchors`, a recursive helper that replaces worktree anchor branches with their non-anchor children during upstack traversal, was copy-pasted verbatim in `internal/actions/navigation/action.go` and `internal/cli/navigation/up.go`.
- Promoted it to `StackGraph.FlattenThroughAnchors` (`internal/engine/stack_graph.go`), next to the graph's other traversal helpers (`ChildBranches`, `Range`, `Upstack`, etc.), and updated both call sites to use it.
- Removes ~26 lines of duplicated logic; behavior is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/... ./internal/actions/navigation/... ./internal/cli/navigation/...` (existing coverage, including `TestFlattenThroughAnchorsPromotesGrandchildren`, passes unchanged against the new method)
- [x] `gofmt -l` / `go vet` clean on touched files


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw422DH9cGcmZoGpwxXcT5)_