### PR TITLE
perf: batch NeedsRestack computation in HTTP API mapping layer

### DIFF
--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -63,13 +63,15 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), names)
 	}
 
-	// One remote listing, one stats pass, one commits pass, and one commit-info
-	// pass for all branches instead of one of each per branch.
+	// One remote listing, one stats pass, one commits pass, one commit-info
+	// pass, and one restack-status pass for all branches instead of one of
+	// each per branch.
 	branchSet := engine.BranchesOf(branches...)
 	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet)
 	stats := entry.Engine.BatchBranchStats(branchSet)
 	commitsByBranch := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)
 	commitInfoByBranch := entry.Engine.BatchCommitInfo(branchSet)
+	statuses := entry.Engine.ReadBranchStatuses(branchSet)
 
 	responses := make([]httpcontract.BranchResponse, 0, len(branches))
 	for _, branch := range branches {
@@ -79,7 +81,7 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		}
 		checks := checksMap.Get(branch.GetName())
 		name := branch.GetName()
-		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch), stats[name], commitsByBranch[name], commitInfoByBranch[name]))
+		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch), stats[name], commitsByBranch[name], commitInfoByBranch[name], !statuses.IsUpToDate(branch)))
 	}
 
 	writeJSON(w, responses)
@@ -110,6 +112,7 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, entr
 	stat := entry.Engine.BatchBranchStats(branchSet)[branchName]
 	commits := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)[branchName]
 	commitInfo := entry.Engine.BatchCommitInfo(branchSet)[branchName]
-	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus, stat, commits, commitInfo)
+	needsRestack := !entry.Engine.ReadBranchStatuses(branchSet).IsUpToDate(branch)
+	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus, stat, commits, commitInfo, needsRestack)
 	writeJSON(w, resp)
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -13,16 +13,17 @@ import (
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
-// remoteStatus, stat, commits, and commitInfo should each come from a single
-// batch call covering all branches being mapped in the current request
-// (ReadBranchRemoteStatuses, BatchBranchStats, BatchCommits, BatchCommitInfo),
-// not per-branch calls — per-branch reads spawn a git process per field per branch.
-func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus, stat engine.BranchStat, commits []string, commitInfo git.CommitInfo) BranchResponse {
+// remoteStatus, stat, commits, commitInfo, and needsRestack should each come
+// from a single batch call covering all branches being mapped in the current
+// request (ReadBranchRemoteStatuses, BatchBranchStats, BatchCommits,
+// BatchCommitInfo, ReadBranchStatuses), not per-branch calls — per-branch
+// reads spawn a git process per field per branch.
+func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus, stat engine.BranchStat, commits []string, commitInfo git.CommitInfo, needsRestack bool) BranchResponse {
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
 		IsCurrent:    branch.GetName() == eng.CurrentBranchName(),
-		NeedsRestack: branch.NeedsRestack(),
+		NeedsRestack: needsRestack,
 		IsLocked:     branch.IsLocked(),
 		IsFrozen:     branch.IsFrozen(),
 		Children:     node.Children,
@@ -95,8 +96,16 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		}
 	}
 
-	// Compute stack status using display branches (anchor excluded)
-	status := computeStackStatus(graph, displayBranches)
+	// Compute stack status using display branches (anchor excluded). Parent
+	// revisions are resolved in one batch call instead of one per branch.
+	displayBranchObjs := make(engine.Branches, 0, len(displayBranches))
+	for _, name := range displayBranches {
+		if node := graph.GetNode(name); node != nil {
+			displayBranchObjs = append(displayBranchObjs, node.Branch)
+		}
+	}
+	statuses := eng.ReadBranchStatuses(displayBranchObjs)
+	status := computeStackStatus(graph, displayBranches, statuses)
 
 	// Title and description come exclusively from explicit stack descriptions
 	// set via `stackit describe`. No fallback to PR titles or branch names.
@@ -152,18 +161,20 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		stackBranches = append(stackBranches, node.Branch)
 	}
 
-	// One remote listing, one stats pass, one commits pass, and one commit-info
-	// pass for the whole stack instead of one of each per branch.
+	// One remote listing, one stats pass, one commits pass, one commit-info
+	// pass, and one restack-status pass for the whole stack instead of one of
+	// each per branch.
 	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, stackBranches)
 	stats := eng.BatchBranchStats(stackBranches)
 	commitsByBranch := eng.BatchCommits(stackBranches, engine.CommitFormatReadableWithDate)
 	commitInfoByBranch := eng.BatchCommitInfo(stackBranches)
+	statuses := eng.ReadBranchStatuses(stackBranches)
 
 	branches := make([]BranchResponse, 0, len(nodes))
 	for _, node := range nodes {
 		name := node.Branch.GetName()
 		checks := checksMap.Get(name)
-		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name], commitInfoByBranch[name])
+		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name], commitInfoByBranch[name], !statuses.IsUpToDate(node.Branch))
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {
@@ -240,8 +251,10 @@ func mapCommitsWithDate(lines []string) []CommitResponse {
 	return commits
 }
 
-// computeStackStatus determines the overall status of a stack.
-func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
+// computeStackStatus determines the overall status of a stack. statuses
+// should come from a single ReadBranchStatuses batch call covering
+// branchNames, not per-branch NeedsRestack() calls.
+func computeStackStatus(graph *engine.StackGraph, branchNames []string, statuses engine.BranchStatuses) string {
 	allHavePR := true
 	anyNeedsRestack := false
 	anyLocked := false
@@ -253,7 +266,7 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 		}
 		branch := node.Branch
 
-		if branch.NeedsRestack() {
+		if !statuses.IsUpToDate(branch) {
 			anyNeedsRestack = true
 		}
 		if branch.IsLocked() {


### PR DESCRIPTION
## Summary

`MapBranch` computed `NeedsRestack` by calling `branch.NeedsRestack()`, which resolves the parent's current revision via a fresh, uncached `git rev-parse` subprocess. Every other field passed into `MapBranch` (remote status, stats, commits, commit info) is deliberately pre-resolved once via a `Batch*`/`ReadBranch*` call over the whole branch set — the function's own doc comment spells this out — but `NeedsRestack` was the one field that bypassed it.

For a repo with N tracked branches, `GET /branches` and the `/view` dashboard endpoint (the highest-traffic API endpoint) each spawned up to N extra `git rev-parse` subprocesses purely to compute restack status.

This switches all of that to the engine's existing `ReadBranchStatuses` batch API, which resolves all distinct parent revisions in a single `git` call. This is the same API already used the same way in `internal/actions/*` and `internal/tui/tree_renderer.go`.

- `MapBranch` now takes a pre-computed `needsRestack bool` instead of calling `branch.NeedsRestack()` internally.
- `computeStackStatus` now takes a pre-computed `engine.BranchStatuses` instead of calling `branch.NeedsRestack()` per branch in its loop.
- `MapStackSummary`, `MapStackDetail`, and the two `MapBranch` call sites in `internal/api/handlers/branches.go` each compute `ReadBranchStatuses` once over their branch set and pass the result down.

`internal/api/handlers/stacks.go` and `internal/api/handlers/view_assembler.go` pick up the fix automatically since they only call into `MapStackSummary`/`MapStackDetail`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/contracts/http/... ./internal/api/... ./internal/engine/...` — all pass
- [x] `gofmt -l` on changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_018wruh2hWqeCjXWSGgTNe6Y)_