### PR TITLE
perf(test): stop pre-baking a legacy JSON config into test repos

### DIFF
--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,8 +1,6 @@
 package cli_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,10 +17,8 @@ func TestInitCommand(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
 
-		// Remove existing config to test fresh init
-		configPath := filepath.Join(s.Scene.Dir, ".git", ".stackit_config")
-		_ = os.Remove(configPath)
-		// Ignore error if file doesn't exist
+		// Start from a repo that has never run `stackit init`.
+		testhelpers.MakeUninitialized(t, s.Scene.Dir)
 
 		// Run init command
 		output, err := s.RunCliAndGetOutput("init", "--trunk", "main")
@@ -61,9 +57,8 @@ Pro-tip: enhance your workflow with integrations:
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
 
-		// Remove existing config
-		configPath := filepath.Join(s.Scene.Dir, ".git", ".stackit_config")
-		os.Remove(configPath)
+		// Start from a repo that has never run `stackit init`.
+		testhelpers.MakeUninitialized(t, s.Scene.Dir)
 
 		// Run init with non-existent branch
 		output, err := s.RunCliAndGetOutput("init", "--trunk", "random")
@@ -84,9 +79,8 @@ Pro-tip: enhance your workflow with integrations:
 			return sc.Repo.RunGitCommand("branch", "-m", "main2")
 		}).WithInProcess(true)
 
-		// Remove existing config
-		configPath := filepath.Join(s.Scene.Dir, ".git", ".stackit_config")
-		os.Remove(configPath)
+		// Start from a repo that has never run `stackit init`.
+		testhelpers.MakeUninitialized(t, s.Scene.Dir)
 
 		// Run init with non-existent branch and no way to infer
 		output, err := s.RunCliAndGetOutput("init", "--trunk", "random")
@@ -100,9 +94,8 @@ Pro-tip: enhance your workflow with integrations:
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
 
-		// Remove existing config
-		configPath := filepath.Join(s.Scene.Dir, ".git", ".stackit_config")
-		os.Remove(configPath)
+		// Start from a repo that has never run `stackit init`.
+		testhelpers.MakeUninitialized(t, s.Scene.Dir)
 
 		// Run init without specifying trunk (should infer main)
 		output, err := s.RunCliAndGetOutput("init")

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/getstackit/stackit/testhelpers"
 )
 
-// removeDefaultConfig removes the default JSON config file created by test setup
-// so we can test fresh/uninitialized state.
+// removeDefaultConfig returns a scene to fresh/uninitialized state. Scenes are
+// marked initialized at setup (stackit.trunk in git config); clearing that key
+// is what "never ran stackit init" means, and it is also what makes
+// needsMigration act on a legacy .stackit_config a test writes.
 func removeDefaultConfig(t *testing.T, dir string) {
 	t.Helper()
-	configPath := filepath.Join(dir, ".git", ".stackit_config")
-	_ = os.Remove(configPath)
+	testhelpers.MakeUninitialized(t, dir)
 }
 
 func TestGitConfigBasicOperations(t *testing.T) {
@@ -388,6 +389,8 @@ func TestMigrationFromJSON(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create JSON config (overwrite the default one created by test setup)
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		footer := false
 		depth := 15
@@ -445,6 +448,8 @@ func TestMigrationFromJSON(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create JSON config with legacy combine.* fields
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		timeout := 120
 		config := &RepoConfig{
@@ -469,6 +474,8 @@ func TestMigrationFromJSON(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create JSON config with both new and legacy CI fields
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		newTimeout := 300
 		legacyTimeout := 120
@@ -503,7 +510,8 @@ func TestMigrationFromJSON(t *testing.T) {
 		err = cfg.SetSubmitFooter(false)
 		require.NoError(t, err)
 
-		// Now create a JSON config that would migrate differently
+		// Now create a JSON config that would migrate differently. Trunk is
+		// deliberately left set — that is what must suppress the migration.
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		footer := true
 		config := &RepoConfig{
@@ -544,6 +552,8 @@ func TestMigrationFromJSON(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create empty JSON config
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		err := os.WriteFile(configPath, []byte("{}"), 0600)
 		require.NoError(t, err)
@@ -558,6 +568,8 @@ func TestMigrationFromJSON(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create corrupt JSON config
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		err := os.WriteFile(configPath, []byte("not valid json{"), 0600)
 		require.NoError(t, err)

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -29,6 +29,8 @@ func TestConfigSubmitFooter(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create config file without submit.footer
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		config := &RepoConfig{
 			Trunk: new("main"),
@@ -48,6 +50,8 @@ func TestConfigSubmitFooter(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create config file with submit.footer = true
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		enabled := true
 		config := &RepoConfig{
@@ -69,6 +73,8 @@ func TestConfigSubmitFooter(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, nil)
 
 		// Create config file with submit.footer = false
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		enabled := false
 		config := &RepoConfig{
@@ -233,6 +239,8 @@ func TestConfigCICommand(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, nil)
 
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		config := &RepoConfig{
 			Trunk:     new("main"),
@@ -252,6 +260,8 @@ func TestConfigCICommand(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, nil)
 
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		config := &RepoConfig{
 			Trunk:            new("main"),
@@ -271,6 +281,8 @@ func TestConfigCICommand(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, nil)
 
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		config := &RepoConfig{
 			Trunk:            new("main"),
@@ -323,6 +335,8 @@ func TestConfigCITimeout(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, nil)
 
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		timeout := 300
 		config := &RepoConfig{
@@ -343,6 +357,8 @@ func TestConfigCITimeout(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, nil)
 
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		timeout := 120
 		config := &RepoConfig{
@@ -363,6 +379,8 @@ func TestConfigCITimeout(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, nil)
 
+		// Migration only acts on a repo that has not been initialized in git config.
+		testhelpers.MakeUninitialized(t, scene.Dir)
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		newTimeout := 180
 		legacyTimeout := 300
@@ -409,6 +427,8 @@ func TestConfigApprovedHooks_LegacyJSONMigration(t *testing.T) {
 	// the new per-phase API so older repos keep working.
 	scene := testhelpers.NewSceneParallel(t, nil)
 
+	// Migration only acts on a repo that has not been initialized in git config.
+	testhelpers.MakeUninitialized(t, scene.Dir)
 	configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 	legacy := &RepoConfig{
 		Trunk:                           new("main"),

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -99,7 +99,6 @@ func NewTestShellInProcess(t *testing.T, opts ...TestShellOption) *TestShell {
 		sh := newTestShellWithRemote(t, "", inprocess.NewInProcessCLI())
 		// Force non-interactive mode for in-process execution
 		utils.SetInteractive(false)
-		sh.ensureTrunkConfig()
 		return sh
 	}
 
@@ -112,8 +111,6 @@ func NewTestShellInProcess(t *testing.T, opts ...TestShellOption) *TestShell {
 	// Force non-interactive mode for in-process execution to match behavior
 	// of spawning binary with --no-interactive
 	utils.SetInteractive(false)
-	// Pre-seed git config to avoid per-test init overhead.
-	sh.ensureTrunkConfig()
 	return sh
 }
 
@@ -129,14 +126,6 @@ func newTestShellWithRemote(t *testing.T, binaryPath string, inProcessCLI *inpro
 	t.Helper()
 	scene := testhelpers.NewRemoteSceneParallel(t)
 	return &TestShell{t: t, scene: scene, binaryPath: binaryPath, inProcessCLI: inProcessCLI}
-}
-
-// ensureTrunkConfig sets the trunk config directly to avoid calling `stackit init`
-// for every test. This keeps tests fast and still marks the repo as initialized.
-func (s *TestShell) ensureTrunkConfig() {
-	s.t.Helper()
-	// Default trunk branch for test repos is main.
-	require.NoError(s.t, s.scene.Repo.RunGitCommand("config", "--local", "stackit.trunk", "main"))
 }
 
 // Scene returns the underlying test scene for direct access when needed.

--- a/internal/integration/init_test.go
+++ b/internal/integration/init_test.go
@@ -27,6 +27,10 @@ func TestInitIntegration(t *testing.T) {
 
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
+		// Migration only runs on a repo that has not been initialized in git
+		// config — that key is exactly what the migration writes.
+		testhelpers.MakeUninitialized(t, scene.Dir)
+
 		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
 		jsonConfig := `{
 			"trunk": "main",

--- a/testhelpers/scene.go
+++ b/testhelpers/scene.go
@@ -409,14 +409,16 @@ func NewRemoteSceneParallel(t *testing.T) *Scene {
 // writeStackitConfigs writes the default Stackit configuration files to a directory.
 // This is used both for templates and for non-template repos.
 func writeStackitConfigs(dir string) error {
-	// Write repo config (JSON format, matching cuteString output)
-	repoConfigPath := filepath.Join(dir, ".git", ".stackit_config")
-	repoConfig := `{
-  "trunk": "main",
-  "isGithubIntegrationEnabled": false
-}
-`
-	if err := os.WriteFile(repoConfigPath, []byte(repoConfig), 0600); err != nil {
+	// Mark the repo initialized in git config, the modern storage location.
+	//
+	// This used to pre-bake a legacy .stackit_config JSON file and rely on the
+	// first LoadConfig migrating it into git config. That made every scene look
+	// like an un-migrated legacy repo, so needsMigration got past its os.Stat
+	// short-circuit and spawned `git config --get stackit.trunk` on EVERY
+	// LoadConfig call, in every test — and the migration never completed,
+	// because it writes the same key it checks. Tests that need a genuinely
+	// uninitialized repo call MakeUninitialized.
+	if err := MarkInitialized(dir); err != nil {
 		return err
 	}
 
@@ -431,6 +433,34 @@ func writeStackitConfigs(dir string) error {
 	}
 
 	return nil
+}
+
+// MarkInitialized sets the trunk key that marks a repo as having run
+// `stackit init`, without paying for the command. Scenes start uninitialized;
+// harnesses whose tests assume an initialized repo call this once at setup.
+func MarkInitialized(dir string) error {
+	cmd := exec.Command("git", "config", "--local", "stackit.trunk", "main")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to set stackit.trunk in %s: %w", dir, err)
+	}
+	return nil
+}
+
+// MakeUninitialized returns a scene directory to the state of a repo that has
+// never run `stackit init`, by clearing the trunk key that marks it
+// initialized. Use it in tests that exercise init or legacy-JSON migration —
+// both branch on stackit.trunk being unset.
+func MakeUninitialized(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--local", "--unset", "stackit.trunk")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	// Exit code 5 means the key was already absent, which is the desired state.
+	if err := cmd.Run(); err != nil && cmd.ProcessState.ExitCode() != 5 {
+		t.Fatalf("failed to unset stackit.trunk in %s: %v", dir, err)
+	}
 }
 
 // BasicSceneSetup is a setup function that creates a basic scene with a single commit.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Every test scene shipped a .stackit_config JSON file so the first LoadConfig
would migrate it into git config. The side effect was that every scene looked
like an un-migrated legacy repo, so needsMigration got past its os.Stat
short-circuit and spawned `git config --get stackit.trunk` on EVERY LoadConfig
call, in every test. The migration never completed either — the harness had
already set the key migration writes, so the JSON was never renamed away.

Templates now mark the repo initialized in git config directly. Tests that need
a genuinely uninitialized repo (init, and the legacy-JSON migration cases) say
so with MakeUninitialized instead of deleting a file whose absence only
happened to imply it.

Cuts `config --get stackit.trunk` by 58% in the integration tier and drops the
now-redundant per-shell ensureTrunkConfig spawn.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1787112074`.


* **PR #1675** 👈
  * **PR #1680**
    * **PR #1679**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1684 by jonnii*