### PR TITLE
perf(git): read HEAD directly and stop peeling metadata refs

### DIFF
--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -370,6 +370,14 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
+	return newContextWithConfig(ctx, repoRoot, opts, writer, cfg)
+}
+
+// newContextWithConfig builds the runtime context from an already-loaded
+// config. Callers that have had to load the config anyway — GetContextWithWriter
+// reads it to check initialization — reuse it instead of paying for a second
+// load, which costs a git process and a project-config read on every command.
+func newContextWithConfig(ctx context.Context, repoRoot string, opts GlobalOptions, writer io.Writer, cfg *config.GitConfig) (*Context, error) {
 	trunk := cfg.Trunk()
 	maxUndoDepth := cfg.UndoStackDepth()
 	maxConcurrency := cfg.MaxConcurrency()
@@ -459,5 +467,7 @@ func GetContextWithWriter(ctx context.Context, opts GlobalOptions, writer io.Wri
 		return nil, fmt.Errorf("stackit not initialized. Run 'stackit init' first")
 	}
 
-	return NewContextAutoWithWriter(ctx, repoRoot, opts, writer)
+	// Demo mode returned above, so the demo branch in NewContextAutoWithWriter
+	// cannot apply here; go straight to the builder and reuse cfg.
+	return newContextWithConfig(ctx, repoRoot, opts, writer, cfg)
 }

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -3,16 +3,50 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 )
 
 func (r *runner) GetCurrentBranch() (string, error) {
+	if name, ok := r.readHeadBranch(); ok {
+		return name, nil
+	}
 	out, err := r.RunGitCommandWithContext(context.Background(), "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("HEAD is not on a branch: %w", err)
 	}
 	return strings.TrimSpace(out), nil
+}
+
+// readHeadBranch reads the checked-out branch straight out of the HEAD file,
+// which is all `git symbolic-ref --short HEAD` does. The current branch is
+// read constantly — it was the second-largest source of git processes in the
+// suite — and a file read is orders of magnitude cheaper than a process.
+//
+// Reports ok=false for anything other than a plain refs/heads symref (detached
+// HEAD, an unreadable file, a symref pointing outside refs/heads). The caller
+// then runs the real command, so git stays the authority on every case except
+// the overwhelmingly common one. Note this reads the worktree's own git dir,
+// not the common dir: each worktree has its own HEAD.
+func (r *runner) readHeadBranch() (string, bool) {
+	if err := r.ensureRepo(); err != nil {
+		return "", false
+	}
+	gitDir := r.getGitDir(context.Background())
+	if gitDir == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return "", false
+	}
+	name, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "ref: refs/heads/")
+	if !ok || name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 // ResolveBranchNameCase reconciles a branch name reported by HEAD with the

--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -13,9 +13,23 @@ import (
 //
 // On failure the returned error string contains "reference not found" so
 // downstream callers that match on that legacy phrase continue to work.
+// stackitRefPrefix is the namespace holding stackit's metadata refs, which
+// point at blobs rather than commits.
+const stackitRefPrefix = "refs/stackit/"
+
 func (r *runner) resolveRefSHA(ref string) (string, error) {
-	out, err := r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
-	if err != nil {
+	var out string
+	var err error
+
+	// Refs under refs/stackit/ address metadata blobs, never commits, so the
+	// ^{commit} peel can only ever fail for them — it was costing a guaranteed
+	// wasted git process on every metadata read. Skipping it is safe beyond
+	// blobs too: peeling is only load-bearing for annotated tags, and no tag
+	// lives in this namespace.
+	if !strings.HasPrefix(ref, stackitRefPrefix) {
+		out, err = r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
+	}
+	if err != nil || out == "" {
 		// Fall back to the non-commit form: tags pointing at trees/blobs, or
 		// generic ref lookups that aren't commits. Most stackit call sites
 		// only care about commits, so try ^{commit} first to fail fast on


### PR DESCRIPTION
- perf(git): read HEAD directly and stop peeling metadata refs
- perf(app): stop loading the config twice per command

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1675**
  * **PR #1680**
    * **PR #1679** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->