### PR TITLE
fix(github): pick the live PR when a branch has several

### DIFF
--- a/internal/github/pr_info_graphql.go
+++ b/internal/github/pr_info_graphql.go
@@ -53,7 +53,11 @@ func buildPRInfoByBranchQuery(repo Repo, branches []string) (string, map[string]
 	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
 	for i := range branches {
 		fmt.Fprintf(&b, "    b%d: ref(qualifiedName: $b%d) {\n", i, i)
-		b.WriteString("      associatedPullRequests(first: 1, orderBy: {field: CREATED_AT, direction: DESC}) {\n")
+		// GitHub does not honor orderBy on associatedPullRequests, so asking
+		// for a single node returns an arbitrary one — in practice the oldest,
+		// which is a closed PR whenever a branch has been resubmitted. Fetch
+		// the set and choose in selectPullRequestInfo instead.
+		fmt.Fprintf(&b, "      associatedPullRequests(first: %d) {\n", associatedPRFetchLimit)
 		b.WriteString("        nodes { " + pullRequestInfoFields + " }\n")
 		b.WriteString("      }\n")
 		b.WriteString("    }\n")
@@ -165,13 +169,64 @@ func parsePRInfoByBranchResponse(body []byte, branches []string) (map[string]*Pu
 		if !ok || len(nodes) == 0 {
 			continue
 		}
-		node, ok := nodes[0].(map[string]any)
-		if !ok {
-			continue
+		infos := make([]*PullRequestInfo, 0, len(nodes))
+		for _, n := range nodes {
+			node, ok := n.(map[string]any)
+			if !ok {
+				continue
+			}
+			infos = append(infos, pullRequestInfoFromGraphQLNode(node))
 		}
-		results[name] = pullRequestInfoFromGraphQLNode(node)
+		if selected := selectPullRequestInfo(infos); selected != nil {
+			results[name] = selected
+		}
 	}
 	return results, nil
+}
+
+// associatedPRFetchLimit caps how many of a branch's associated PRs are
+// examined. A branch accumulates one per submission cycle; ten covers any
+// realistic history without paging.
+const associatedPRFetchLimit = 10
+
+// selectPullRequestInfo picks the PR that represents a branch's current state.
+//
+// A branch can have several associated PRs — closing one and opening another
+// for the same head leaves both attached forever. An OPEN PR is always the
+// live one; failing that a MERGED PR describes what happened to the branch,
+// and only then does a CLOSED PR apply. Within a state the highest number is
+// the most recent.
+//
+// Getting this wrong is not cosmetic: adopting a stale CLOSED PR makes submit
+// try to create a PR that already exists, and makes sync treat a live branch
+// as landed work to delete.
+func selectPullRequestInfo(infos []*PullRequestInfo) *PullRequestInfo {
+	rank := func(state git.PRState) int {
+		switch state {
+		case git.PRStateOpen:
+			return 3
+		case git.PRStateMerged:
+			return 2
+		default:
+			return 1
+		}
+	}
+
+	var best *PullRequestInfo
+	for _, info := range infos {
+		if info == nil {
+			continue
+		}
+		switch {
+		case best == nil:
+		case rank(info.State) > rank(best.State):
+		case rank(info.State) == rank(best.State) && info.Number > best.Number:
+		default:
+			continue
+		}
+		best = info
+	}
+	return best
 }
 
 // pullRequestInfoFromGraphQLNode converts a single associatedPullRequests node

--- a/internal/github/pr_info_graphql_test.go
+++ b/internal/github/pr_info_graphql_test.go
@@ -16,7 +16,7 @@ func TestBuildPRInfoByBranchQuery(t *testing.T) {
 	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
 	require.Contains(t, query, "b0: ref(qualifiedName: $b0)")
 	require.Contains(t, query, "b1: ref(qualifiedName: $b1)")
-	require.Contains(t, query, "associatedPullRequests(first: 1, orderBy: {field: CREATED_AT, direction: DESC})")
+	require.Contains(t, query, "associatedPullRequests(first: 10)")
 	require.Contains(t, query, "number title body state url isDraft baseRefName headRefName")
 
 	require.Equal(t, "octo", variables["owner"])
@@ -137,4 +137,63 @@ func TestParsePRInfoByBranchResponse_InvalidJSON(t *testing.T) {
 
 	_, err := parsePRInfoByBranchResponse([]byte(`{invalid`), []string{"feature"})
 	require.Error(t, err)
+}
+
+// TestParsePRInfoByBranchResponse_PrefersLivePR covers the shape GitHub
+// actually returns for a resubmitted branch: several associated PRs, with a
+// closed one first because orderBy is not honored on this connection.
+// Adopting that closed PR made submit try to create a PR that already existed
+// and made sync treat a live branch as landed work.
+func TestParsePRInfoByBranchResponse_PrefersLivePR(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data":{"repository":{
+		"b0":{"associatedPullRequests":{"nodes":[
+			{"number":1677,"state":"CLOSED","baseRefName":"old-base","headRefName":"feature"},
+			{"number":1680,"state":"OPEN","baseRefName":"new-base","headRefName":"feature"}
+		]}}
+	}}}`)
+
+	infos, err := parsePRInfoByBranchResponse(body, []string{"feature"})
+	require.NoError(t, err)
+	require.Equal(t, 1680, infos["feature"].Number)
+	require.Equal(t, git.PRStateOpen, infos["feature"].State)
+	require.Equal(t, "new-base", infos["feature"].Base)
+}
+
+func TestSelectPullRequestInfo(t *testing.T) {
+	t.Parallel()
+
+	open1 := &PullRequestInfo{Number: 10, State: git.PRStateOpen}
+	open2 := &PullRequestInfo{Number: 12, State: git.PRStateOpen}
+	merged := &PullRequestInfo{Number: 20, State: git.PRStateMerged}
+	closedOld := &PullRequestInfo{Number: 3, State: git.PRStateClosed}
+	closedNew := &PullRequestInfo{Number: 30, State: git.PRStateClosed}
+
+	tests := []struct {
+		name  string
+		infos []*PullRequestInfo
+		want  int
+	}{
+		{"open beats closed regardless of number", []*PullRequestInfo{closedNew, open1}, 10},
+		{"open beats merged regardless of number", []*PullRequestInfo{merged, open1}, 10},
+		{"newest open wins among open", []*PullRequestInfo{open1, open2}, 12},
+		{"merged beats closed", []*PullRequestInfo{closedNew, merged}, 20},
+		{"newest closed when nothing else", []*PullRequestInfo{closedOld, closedNew}, 30},
+		{"nil entries ignored", []*PullRequestInfo{nil, open1}, 10},
+		{"empty yields nothing", nil, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := selectPullRequestInfo(tt.infos)
+			if tt.want == 0 {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.want, got.Number)
+		})
+	}
 }


### PR DESCRIPTION

A branch keeps every pull request ever opened for it: closing one and opening
another for the same head leaves both attached forever. We asked for one node
with orderBy CREATED_AT DESC and took it — but GitHub does not honor orderBy on
associatedPullRequests, so the node returned is arbitrary, and in practice the
oldest. A resubmitted branch therefore adopted a CLOSED PR.

That is not cosmetic. The stale number is written into branch metadata, so
submit tries to create a PR that already exists and fails with a 422 on every
run, and sync sees a closed PR against a live branch — which it is built to
delete and reparent children past.

Fetch the set and choose: an OPEN PR is the live one, a MERGED PR describes
what became of the branch, and only then does CLOSED apply; highest number wins
within a state.

Reproduced against a real branch carrying #1677 (closed) and #1680 (open),
where the API returns the closed one first.