### PR TITLE
fix(github): rebuild a native Stack that no longer matches the chain

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -727,6 +727,8 @@ func githubStackActionLabel(action github.StackSyncAction) string {
 		return "Created"
 	case github.StackSyncExtended:
 		return "Extended"
+	case github.StackSyncRebuilt:
+		return "Rebuilt"
 	default:
 		return "Already linked to"
 	}

--- a/internal/github/stacks.go
+++ b/internal/github/stacks.go
@@ -23,6 +23,7 @@ type StackClient interface {
 	CreateStack(ctx context.Context, pullRequests []int) (*StackInfo, error)
 	FindStackByPullRequest(ctx context.Context, pullRequest int) (*StackInfo, error)
 	AddPullRequestsToStack(ctx context.Context, stackNumber int, pullRequests []int) (*StackInfo, error)
+	UnstackStack(ctx context.Context, stackNumber int) (bool, error)
 }
 
 // StackInfo is GitHub's server-side representation of a linear stack of pull
@@ -61,6 +62,7 @@ const (
 	StackSyncCreated   StackSyncAction = "created"
 	StackSyncExtended  StackSyncAction = "extended"
 	StackSyncUnchanged StackSyncAction = "unchanged"
+	StackSyncRebuilt   StackSyncAction = "rebuilt"
 )
 
 // EnsureStack creates, extends, or leaves unchanged the native GitHub Stack
@@ -89,7 +91,60 @@ func EnsureStack(ctx context.Context, client StackClient, pullRequests []int) (*
 		return stack, StackSyncExtended, err
 	}
 
-	return nil, "", fmt.Errorf("GitHub Stack #%d has PRs %v, which do not match the submitted chain %v", existing.Number, existingPRs, pullRequests)
+	return rebuildStack(ctx, client, existing, existingPRs, pullRequests)
+}
+
+// rebuildStack dissolves a stack whose contents no longer match the submitted
+// chain and recreates it from that chain.
+//
+// GitHub's Stacks API can only append to the top of a stack — there is no
+// endpoint that removes an individual pull request. So a stack that diverges
+// (typically because a PR in it was closed and resubmitted as a new one, or a
+// branch was folded away) has exactly one repair: unstack it and create it
+// again. Without this, every later submit reported a mismatch and skipped
+// native Stack sync forever, with nothing the user could do from stackit.
+//
+// Unstack removes only the pull requests GitHub allows to leave a stack;
+// merged, merging, and queued ones stay. Rather than guess which those are —
+// the API reports a merged PR's state as "closed", indistinguishable from a
+// closed one — attempt the unstack and let GitHub answer: the stack dissolves
+// only when nothing was pinned in place.
+func rebuildStack(ctx context.Context, client StackClient, existing *StackInfo, existingPRs, pullRequests []int) (*StackInfo, StackSyncAction, error) {
+	dissolved, err := client.UnstackStack(ctx, existing.Number)
+	if err != nil {
+		return nil, "", fmt.Errorf("GitHub Stack #%d has PRs %v, which do not match the submitted chain %v, and it could not be dissolved to rebuild: %w", existing.Number, existingPRs, pullRequests, err)
+	}
+	if !dissolved {
+		return nil, "", fmt.Errorf("GitHub Stack #%d has PRs %v, which do not match the submitted chain %v; the pull requests still in it are merged or queued to merge and cannot be unstacked", existing.Number, existingPRs, pullRequests)
+	}
+
+	stack, err := client.CreateStack(ctx, pullRequests)
+	if err != nil {
+		return nil, "", fmt.Errorf("dissolved GitHub Stack #%d but could not recreate it from %v: %w", existing.Number, pullRequests, err)
+	}
+	return stack, StackSyncRebuilt, nil
+}
+
+// UnstackStack removes every pull request GitHub permits from a native Stack.
+// Reports whether the stack was dissolved outright; false means merged or
+// queued pull requests remain in it.
+func (c *StackitGitHubClient) UnstackStack(ctx context.Context, stackNumber int) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/stacks/%d/unstack", c.repo.Owner, c.repo.Name, stackNumber)
+	req, err := c.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return false, fmt.Errorf("build GitHub Stack unstack request: %w", err)
+	}
+
+	var remaining StackInfo
+	resp, err := c.client.Do(req, &remaining)
+	if err != nil {
+		return false, fmt.Errorf("unstack GitHub Stack #%d: %w", stackNumber, err)
+	}
+	// 204 means the stack is gone; 200 returns whatever is still stacked.
+	if resp != nil && resp.StatusCode == http.StatusNoContent {
+		return true, nil
+	}
+	return len(remaining.PullRequests) == 0, nil
 }
 
 // ValidateStackPullRequestCount validates the GitHub Stacks API's request

--- a/internal/github/stacks_test.go
+++ b/internal/github/stacks_test.go
@@ -109,3 +109,72 @@ func TestEnsureStackSkipsMatchingExistingStack(t *testing.T) {
 	require.Equal(t, StackSyncUnchanged, action)
 	require.Equal(t, 7, stack.Number)
 }
+
+// TestEnsureStackRebuildsDivergedStack covers the state a fold or a
+// close-and-resubmit leaves behind: the stack still lists PRs that are no
+// longer the chain being submitted. GitHub has no endpoint to remove one PR,
+// so the only repair is unstack + create.
+func TestEnsureStackRebuildsDivergedStack(t *testing.T) {
+	t.Parallel()
+
+	var unstacked, created int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/stacks":
+			_, _ = w.Write([]byte(`[{"number": 7, "pull_requests": [{"number": 12}, {"number": 34}, {"number": 56}]}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/stacks/7/unstack":
+			unstacked++
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/stacks":
+			created++
+			var body createStackRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Equal(t, []int{12, 78, 90}, body.PullRequests)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"number": 8, "pull_requests": [{"number": 12}, {"number": 78}, {"number": 90}]}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL)
+		}
+	}))
+	defer server.Close()
+
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithHTTPClient(server.Client()), github.WithURLs(&baseURL, &baseURL))
+	require.NoError(t, err)
+	stackClient := &StackitGitHubClient{client: client, repo: Repo{Owner: "acme", Name: "widget"}}
+
+	stack, action, err := EnsureStack(context.Background(), stackClient, []int{12, 78, 90})
+	require.NoError(t, err)
+	require.Equal(t, StackSyncRebuilt, action)
+	require.Equal(t, 8, stack.Number)
+	require.Equal(t, 1, unstacked)
+	require.Equal(t, 1, created)
+}
+
+// TestEnsureStackRefusesRebuildWhenMergedPRsRemain covers the case GitHub
+// pins in place: merged/queued PRs cannot leave a stack, so unstack returns
+// 200 with them still listed and no rebuild is possible. Creating anyway would
+// fail, so the error has to explain why.
+func TestEnsureStackRefusesRebuildWhenMergedPRsRemain(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/stacks":
+			_, _ = w.Write([]byte(`[{"number": 7, "pull_requests": [{"number": 12}, {"number": 34}]}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/stacks/7/unstack":
+			_, _ = w.Write([]byte(`{"number": 7, "pull_requests": [{"number": 12}]}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL)
+		}
+	}))
+	defer server.Close()
+
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithHTTPClient(server.Client()), github.WithURLs(&baseURL, &baseURL))
+	require.NoError(t, err)
+	stackClient := &StackitGitHubClient{client: client, repo: Repo{Owner: "acme", Name: "widget"}}
+
+	_, _, err = EnsureStack(context.Background(), stackClient, []int{12, 78})
+	require.ErrorContains(t, err, "merged or queued to merge and cannot be unstacked")
+}

--- a/testhelpers/github_mock.go
+++ b/testhelpers/github_mock.go
@@ -26,6 +26,9 @@ type MockGitHubServerConfig struct {
 	// StackError, when set, is returned by every native GitHub Stacks API call.
 	// Repos without access to the experimental API fail this way.
 	StackError error
+	// MergedStackPRs lists PR numbers GitHub refuses to unstack because they
+	// are merged, merging, or queued to merge. Such a stack cannot be rebuilt.
+	MergedStackPRs []int
 	// ErrorResponses maps endpoint+method to error responses
 	ErrorResponses map[string]error
 	// Owner and Repo for the mock server

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -76,6 +76,27 @@ func (c *MockGitHubClient) AddPullRequestsToStack(_ context.Context, stackNumber
 	return mockStackInfo(stackNumber, c.config.CreatedStacks[stackNumber-1]), nil
 }
 
+// UnstackStack empties a mock native Stack, mirroring GitHub dissolving one
+// whose pull requests can all be unstacked. MergedStackPRs, if set, models the
+// pull requests GitHub refuses to remove.
+func (c *MockGitHubClient) UnstackStack(_ context.Context, stackNumber int) (bool, error) {
+	c.config.mu.Lock()
+	defer c.config.mu.Unlock()
+
+	if stackNumber < 1 || stackNumber > len(c.config.CreatedStacks) {
+		return false, fmt.Errorf("GitHub Stack #%d does not exist", stackNumber)
+	}
+
+	var pinned []int
+	for _, pullRequest := range c.config.CreatedStacks[stackNumber-1] {
+		if containsInt(c.config.MergedStackPRs, pullRequest) {
+			pinned = append(pinned, pullRequest)
+		}
+	}
+	c.config.CreatedStacks[stackNumber-1] = pinned
+	return len(pinned) == 0, nil
+}
+
 func mockStackInfo(number int, pullRequests []int) *githubpkg.StackInfo {
 	stack := &githubpkg.StackInfo{Number: number, PullRequests: make([]githubpkg.StackPRInfo, len(pullRequests))}
 	for i, pullRequest := range pullRequests {


### PR DESCRIPTION

GitHub Stacks can only be appended to — the API has no endpoint that removes
an individual pull request. So once a stack diverged from the chain being
submitted, EnsureStack errored and submit skipped native Stack sync on every
run afterwards, with nothing the user could do about it from stackit.

Divergence is not exotic: closing a PR and resubmitting the branch, or folding
a branch that had one, leaves the stack pinned to pull requests that are no
longer in the chain.

The one repair the API supports is unstack followed by create, so do that and
report it as "Rebuilt". Unstack releases only what GitHub allows to leave;
merged, merging, and queued pull requests stay. Rather than guess which those
are — a merged PR reports state "closed", indistinguishable from a closed one —
attempt the unstack and let GitHub answer: the stack dissolves only when
nothing was pinned. If any remain, the error now says so instead of repeating
the mismatch.