### PR TITLE
fix(worktree): ignore worktrees whose directory is gone

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -269,11 +269,21 @@ func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 
 	var result WorktreeList
 	var current Worktree
+	var prunable bool
 	flush := func() {
-		if current.Path != "" {
+		// Drop worktrees git reports as prunable: their directory is gone, so
+		// they are registrations without a checkout. Every caller here asks a
+		// question about a physical checkout — does this worktree hold
+		// uncommitted work, which worktree owns this branch, is a branch
+		// checked out somewhere unmanaged — and a path that does not exist
+		// answers all of them wrongly. Worst of these, an inspection failure
+		// is treated as "unknown, so hold", which turned a leftover temp
+		// worktree into a permanent hold on a branch and its descendants.
+		if current.Path != "" && !prunable {
 			result = append(result, current)
 		}
 		current = Worktree{}
+		prunable = false
 	}
 	for line := range strings.SplitSeq(output, "\x00") {
 		switch {
@@ -284,6 +294,8 @@ func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 			current.Path = strings.TrimPrefix(line, "worktree ")
 		case strings.HasPrefix(line, "branch "):
 			current.Branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
+		case line == "prunable" || strings.HasPrefix(line, "prunable "):
+			prunable = true
 		}
 	}
 	flush()

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -140,6 +140,41 @@ func TestWorktree(t *testing.T) {
 		require.NotContains(t, worktrees.Paths(), worktreePath)
 	})
 
+	t.Run("omits worktrees whose directory is gone", func(t *testing.T) {
+		// A temp worktree deleted without `git worktree remove` — what a
+		// crashed or interrupted merge leaves behind. Git keeps the
+		// registration and marks it prunable.
+		//
+		// Such an entry used to reach the hold logic, which cannot inspect a
+		// missing directory and treats "unknown" as "hold". That pinned the
+		// branch and its descendants out of every restack, permanently, over a
+		// worktree with nothing in it to protect.
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		require.NoError(t, scene.Repo.CreateAndCheckoutBranch("stale-branch"))
+		require.NoError(t, scene.Repo.RunGitCommand("checkout", "main"))
+
+		tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+		require.NoError(t, err)
+		worktreePath := filepath.Join(tmpDir, "doomed")
+		require.NoError(t, runner.AddWorktree(context.Background(), worktreePath, "stale-branch", git.WorktreeAttached))
+
+		worktrees, err := runner.ListWorktrees(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, worktrees.Paths(), worktreePath)
+
+		// Delete the directory behind git's back.
+		require.NoError(t, os.RemoveAll(worktreePath))
+
+		worktrees, err = runner.ListWorktrees(context.Background())
+		require.NoError(t, err)
+		require.NotContains(t, worktrees.Paths(), worktreePath,
+			"a worktree whose directory is gone must not be reported as a checkout")
+		require.Empty(t, worktrees.PathForBranch("stale-branch"),
+			"no worktree should be reported as holding the branch")
+	})
+
 	t.Run("add detached worktree", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)


### PR DESCRIPTION

A worktree deleted without `git worktree remove` — what an interrupted merge
or a cleared temp directory leaves behind — stays registered, and git reports
it as prunable. ListWorktrees parsed only the worktree and branch lines, so
that registration was handed to callers as a real checkout.

Every caller then asks a question about a physical checkout: does this worktree
hold uncommitted work, which worktree owns this branch, is this branch checked
out somewhere unmanaged. A path that does not exist answers all of them
wrongly, and the hold logic answers it in the most damaging way: inspecting the
missing directory fails, an inspection failure is deliberately treated as
"unknown, so hold", and the branch plus its descendants were pinned out of
every restack — protecting a worktree with nothing in it to protect.

Skip prunable entries at the parse, so the fix covers restack, sync, ownership
warnings, and the one-off reset path together rather than each guarding
separately.