### PR TITLE
fix(submit): dissolve a stale native Stack to retarget a PR base

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -536,6 +536,39 @@ func createGitHubStackMetadata(ctx *app.Context, branches engine.Branches) (*git
 	return stack, pullRequests, action, nil
 }
 
+// dissolveGitHubStack removes the native GitHub Stack containing pullRequest.
+// GitHub's Stacks API has no endpoint that drops a single pull request, so
+// unstacking the whole resource is the only way to free a PR's base branch.
+func dissolveGitHubStack(ctx *app.Context, pullRequest int) error {
+	client, err := getGitHubClient(ctx)
+	if err != nil {
+		return err
+	}
+	stackClient, ok := client.(github.StackClient)
+	if !ok {
+		return fmt.Errorf("GitHub Stack API is unavailable for this client")
+	}
+
+	remoteCtx, cancel := ctx.RemoteOperationContext()
+	defer cancel()
+
+	stack, err := stackClient.FindStackByPullRequest(remoteCtx, pullRequest)
+	if err != nil {
+		return err
+	}
+	if stack == nil {
+		return fmt.Errorf("pull request %d is not in a native GitHub Stack", pullRequest)
+	}
+	dissolved, err := stackClient.UnstackStack(remoteCtx, stack.Number)
+	if err != nil {
+		return err
+	}
+	if !dissolved {
+		return fmt.Errorf("GitHub Stack #%d still holds pull requests that are merged or queued to merge", stack.Number)
+	}
+	return nil
+}
+
 // buildStackSnapshot captures the stack relationships and metadata that submit
 // adapters need for rendering.
 func buildStackSnapshot(
@@ -825,6 +858,23 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 	}
 
 	updateWarnings, err := ctx.GitHub().UpdatePullRequest(ctx.Context, *submissionInfo.PRNumber, updateOpts)
+	if err != nil && github.IsStackBaseConflict(err) {
+		// The branch was reparented locally (move, reorder, sync past a merged
+		// parent), so the native GitHub Stack recorded for it no longer describes
+		// the chain — and GitHub refuses base changes while the PR is in one.
+		// Dissolve it; the stack sync at the end of submit rebuilds it from the
+		// current chain. Without this the user is stuck: no stackit command can
+		// retarget the PR, and the stack cannot be repaired from the GitHub UI.
+		if dissolveErr := dissolveGitHubStack(ctx, *submissionInfo.PRNumber); dissolveErr != nil {
+			ctx.Output.Debug("Failed to dissolve native GitHub Stack for %s: %v", submissionInfo.BranchName, dissolveErr)
+		} else {
+			handler.OnEvent(BranchWarningEvent{
+				BranchName: submissionInfo.BranchName,
+				Warning:    "dissolved the native GitHub Stack so the pull request base could be retargeted",
+			})
+			updateWarnings, err = ctx.GitHub().UpdatePullRequest(ctx.Context, *submissionInfo.PRNumber, updateOpts)
+		}
+	}
 	if err != nil {
 		if retargetedToTrunk {
 			// The PR is currently targeting trunk from the base.sha refresh above; restore

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -1027,3 +1027,39 @@ func TestSubmitGitHubStackAcceptsContiguousChain(t *testing.T) {
 	require.Len(t, mockConfig.CreatedStacks, 1)
 	require.Len(t, mockConfig.CreatedStacks[0], 3, "all three PRs should form one native Stack")
 }
+
+// TestSubmitDissolvesNativeGitHubStackToRetargetBase covers reparenting a branch
+// out of a submitted native GitHub Stack (`stackit move` onto trunk). GitHub
+// refuses to change a stacked PR's base, so submit must dissolve the stale
+// Stack and retry rather than failing every time from then on.
+func TestSubmitDissolvesNativeGitHubStackToRetargetBase(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedStacks, 1)
+
+	// Move "api" out of the stack onto trunk, then resubmit just that branch —
+	// too few PRs for a native Stack, so nothing else clears the stale one.
+	s.TrackBranch("api", "main").Checkout("api")
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{})
+	require.NoError(t, err)
+
+	require.Empty(t, mockConfig.CreatedStacks[0], "the stale native Stack should have been dissolved")
+	apiPR, err := s.Engine.GetBranch("api").GetPrInfo()
+	require.NoError(t, err)
+	require.Equal(t, "main", apiPR.Base())
+}

--- a/internal/github/stacks.go
+++ b/internal/github/stacks.go
@@ -2,9 +2,13 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
+
+	"github.com/google/go-github/v90/github"
 )
 
 const (
@@ -145,6 +149,21 @@ func (c *StackitGitHubClient) UnstackStack(ctx context.Context, stackNumber int)
 		return true, nil
 	}
 	return len(remaining.PullRequests) == 0, nil
+}
+
+// IsStackBaseConflict reports whether err is GitHub refusing to retarget a pull
+// request because it belongs to a native Stack. Any stackit operation that
+// reparents a branch — move, reorder, sync past a merged parent — has to change
+// the PR base, and GitHub rejects that outright while the PR sits in a Stack.
+// Callers treat this as "the recorded Stack is stale", not as a user error.
+func IsStackBaseConflict(err error) bool {
+	var resp *github.ErrorResponse
+	if !errors.As(err, &resp) || resp.Response == nil || resp.Response.StatusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+	return slices.ContainsFunc(resp.Errors, func(e github.Error) bool {
+		return e.Field == "base" && strings.Contains(e.Message, "part of a stack")
+	})
 }
 
 // ValidateStackPullRequestCount validates the GitHub Stacks API's request

--- a/internal/github/stacks_test.go
+++ b/internal/github/stacks_test.go
@@ -3,6 +3,8 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -177,4 +179,43 @@ func TestEnsureStackRefusesRebuildWhenMergedPRsRemain(t *testing.T) {
 
 	_, _, err = EnsureStack(context.Background(), stackClient, []int{12, 78})
 	require.ErrorContains(t, err, "merged or queued to merge and cannot be unstacked")
+}
+
+func TestIsStackBaseConflict(t *testing.T) {
+	t.Parallel()
+
+	stackConflict := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+		Errors: []github.Error{{
+			Resource: "PullRequest",
+			Field:    "base",
+			Code:     "invalid",
+			Message:  "Cannot change the base branch because the pull request is part of a stack.",
+		}},
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil},
+		{name: "plain error", err: errors.New("boom")},
+		{name: "stack conflict", err: stackConflict, want: true},
+		{name: "wrapped stack conflict", err: fmt.Errorf("failed to update pull request: %w", stackConflict), want: true},
+		{
+			name: "other 422",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+				Errors:   []github.Error{{Field: "base", Code: "invalid", Message: "No commits between main and feature"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, IsStackBaseConflict(tt.err))
+		})
+	}
 }

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -3,6 +3,7 @@ package testhelpers
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/google/go-github/v90/github"
@@ -135,8 +136,22 @@ func (c *MockGitHubClient) CreatePullRequest(ctx context.Context, opts githubpkg
 	return githubpkg.ToPullRequestInfo(createdPR), nil
 }
 
-// UpdatePullRequest updates an existing pull request
+// UpdatePullRequest updates an existing pull request. A base change is rejected
+// while the pull request sits in a native Stack, mirroring GitHub.
 func (c *MockGitHubClient) UpdatePullRequest(ctx context.Context, prNumber int, opts githubpkg.UpdatePROptions) ([]string, error) {
+	if opts.Base != nil && c.isStacked(prNumber) {
+		return nil, fmt.Errorf("failed to update pull request: %w", &github.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+			Message:  "Validation Failed",
+			Errors: []github.Error{{
+				Resource: "PullRequest",
+				Field:    "base",
+				Code:     "invalid",
+				Message:  "Cannot change the base branch because the pull request is part of a stack.",
+			}},
+		})
+	}
+
 	update := &github.PullRequest{}
 
 	if opts.Title != nil {
@@ -153,6 +168,19 @@ func (c *MockGitHubClient) UpdatePullRequest(ctx context.Context, prNumber int, 
 
 	_, _, err := c.client.PullRequests.Edit(ctx, c.owner, c.repo, prNumber, update)
 	return nil, err
+}
+
+// isStacked reports whether prNumber currently belongs to a mock native Stack.
+func (c *MockGitHubClient) isStacked(prNumber int) bool {
+	c.config.mu.Lock()
+	defer c.config.mu.Unlock()
+
+	for _, stack := range c.config.CreatedStacks {
+		if containsInt(stack, prNumber) {
+			return true
+		}
+	}
+	return false
 }
 
 // GetPullRequestByBranch gets a pull request for a branch


### PR DESCRIPTION

GitHub rejects any base change on a pull request inside a native Stack. Any
stackit operation that reparents a branch (move, reorder, sync past a merged
parent) needs that base change, so submit failed with a 422 and no stackit
command could recover it — the Stack cannot be edited from the GitHub UI
either.

On that specific 422, dissolve the Stack containing the PR and retry the
update once. The stack sync at the end of submit rebuilds it from the current
chain. The mock GitHub client now mirrors the rejection so the repair is
covered end to end.