### PR TITLE
perf(track): parallelize untracked-child merge-base scan

### DIFF
--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Options contains options for the track command
@@ -183,21 +185,35 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 	// branchRev is loop-invariant; a failed lookup just disables child detection.
 	branchRev, revErr := eng.GetRevision(eng.GetBranch(branchName))
 	if revErr == nil {
+		// GetMergeBase spawns a git subprocess per call with no batch/cached
+		// equivalent, so candidates are checked concurrently with a bounded
+		// worker pool instead of serially. Each worker writes only its own
+		// index, so isChild is assembled without synchronization.
+		type indexedCandidate struct {
+			index     int
+			candidate engine.Branch
+		}
+		candidates := make([]indexedCandidate, 0, len(allBranches))
 		for _, candidateBranch := range allBranches {
-			candidate := candidateBranch.GetName()
-			if candidate == branchName {
+			if candidateBranch.GetName() == branchName {
 				continue
 			}
+			candidates = append(candidates, indexedCandidate{index: len(candidates), candidate: candidateBranch})
+		}
 
-			// Check if candidate is a child (has this branch as merge base)
-			mergeBase, err := eng.GetMergeBase(ctx.Context, candidate, branchName)
+		isChild := make([]bool, len(candidates))
+		utils.Run(candidates, func(item indexedCandidate) {
+			mergeBase, err := eng.GetMergeBase(ctx.Context, item.candidate.GetName(), branchName)
 			if err != nil {
-				continue
+				return
 			}
-
 			// If merge base is the branch we just tracked, candidate is a child
-			if mergeBase == branchRev && !candidateBranch.IsTracked() {
-				untrackedChildren = append(untrackedChildren, candidate)
+			isChild[item.index] = mergeBase == branchRev && !item.candidate.IsTracked()
+		})
+
+		for _, item := range candidates {
+			if isChild[item.index] {
+				untrackedChildren = append(untrackedChildren, item.candidate.GetName())
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `trackBranchRecursively` scans every branch in the repo to find untracked children of the branch just tracked, calling `eng.GetMergeBase` once per candidate branch, serially, in a loop.
- `GetMergeBase` has no batch/cached equivalent (unlike `GetRevision`/`ReadMetadata`/etc.), so each call spawns a real `git merge-base` subprocess — an O(branch count) sequential chain of process spawns per `stackit track` invocation, repeated at every level when tracking recurses into children.
- This mirrors exactly the situation documented in `.claude/rules/code-style.md` under "Bound parallel fan-out": a per-item git operation with no batch API, whose fix is a bounded worker pool (`utils.Run`), not one goroutine per item. `internal/engine/branch_view.go` already uses the same indexed-slot pattern for a similar case.
- Replaced the serial loop with `utils.Run` over an indexed candidate slice; each worker writes only its own slot, so results are assembled without synchronization and the resulting child order is unchanged (list order still matches `eng.AllBranches()`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/actions/track/...`
- [x] `go test -race ./internal/actions/track/...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoXtPD9PxmPw4UUPpRVBbx)_