### PR TITLE
test(api): pin /view remote status to one ls-remote across stacks

### DIFF
--- a/internal/api/handlers/view_assembler_test.go
+++ b/internal/api/handlers/view_assembler_test.go
@@ -2,10 +2,13 @@ package handlers
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
@@ -78,4 +81,50 @@ func TestBuildSurvivesDetachedHEAD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, view.Repo.CurrentBranch, "detached HEAD has no current branch")
 	require.NotEmpty(t, view.Stacks, "the stack should still be mapped while detached")
+}
+
+// countingFetchRunner wraps a git.Runner and counts FetchRemoteShas calls, so
+// a test can assert /view reads remote status once for the whole response
+// rather than once per stack. FetchRemoteShas runs `git ls-remote`, a network
+// round trip.
+type countingFetchRunner struct {
+	git.Runner
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingFetchRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+// TestBuildReadsRemoteStatusOnceAcrossStacks reproduces the /view N+1: two
+// independent stacks off trunk must still cost one remote listing, not one
+// per stack.
+func TestBuildReadsRemoteStatusOnceAcrossStacks(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"stack-a": "main", "stack-b": "main"})
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	for _, b := range []string{"main", "stack-a", "stack-b"} {
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", b))
+	}
+
+	counting := &countingFetchRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	a := NewViewAssembler(eng, nil, "origin", VisibilityPublic)
+	view, err := a.Build(context.Background())
+	require.NoError(t, err)
+	require.Len(t, view.Stacks, 2, "stack-a and stack-b are independent stacks off trunk")
+
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"building /view across multiple stacks must read remote status once, not once per stack")
 }


### PR DESCRIPTION
The production change this branch carried was superseded by #1731, which batches remote statuses along with stats, commits, commit info and restack status across every stack in a request. Rebasing onto that left those hunks redundant, so they are dropped — this PR is now purely the regression test.

The test is worth keeping on its own: it counts `FetchRemoteShas` calls through a wrapping `git.Runner` and asserts a two-stack `/view` costs one `ls-remote`, not one per stack. Nothing else pins that property, so a future refactor could reintroduce the N+1 silently.

Verified by reintroducing the per-stack fetch locally: the test fails with `expected: 1, actual: 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5zKhmyrp4h1uABMakqDPV