### PR TITLE
perf(engine): parallelize per-branch merge-base computation in ReadBranchRemoteStatuses

### DIFF
--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // IsTrunk checks if a branch is the trunk
@@ -262,8 +263,21 @@ func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Bran
 		remoteShas = map[string]string{}
 	}
 
-	for _, branch := range branches {
-		branchName := branch.GetName()
+	// Each worker writes only its own index, so the slice is filled without
+	// synchronization and assembled into the result map serially afterward,
+	// mirroring batchByBranch in branch_view.go.
+	type indexedBranch struct {
+		index  int
+		branch Branch
+	}
+	indexed := make([]indexedBranch, len(branches))
+	statuses := make([]BranchRemoteStatus, len(branches))
+	for i, b := range branches {
+		indexed[i] = indexedBranch{index: i, branch: b}
+	}
+
+	utils.Run(indexed, func(item indexedBranch) {
+		branchName := item.branch.GetName()
 		localSha := localShas[branchName]
 		remoteSha := remoteShas[branchName]
 		if remoteSha == "" {
@@ -287,7 +301,11 @@ func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Bran
 			}
 		}
 
-		results[branchName] = status
+		statuses[item.index] = status
+	})
+
+	for i, b := range branches {
+		results[b.GetName()] = statuses[i]
 	}
 
 	return results

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -1302,6 +1302,43 @@ func TestReadBranchRemoteStatuses(t *testing.T) {
 		status := s.Engine.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(main)).ForBranch(main)
 		require.False(t, status.Matches(), "main should not match empty remote")
 	})
+
+	t.Run("computes common ancestor for multiple diverged branches concurrently", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
+
+		// Push feature1 and feature2, then diverge each with a local-only commit
+		// so every branch needs its own merge-base computation.
+		s.CreateBranch("feature1").Commit("feature1 base")
+		err = s.Scene.Repo.PushBranch("origin", "feature1")
+		require.NoError(t, err)
+		s.Commit("feature1 local-only change")
+
+		s.Checkout("main")
+		s.CreateBranch("feature2").Commit("feature2 base")
+		err = s.Scene.Repo.PushBranch("origin", "feature2")
+		require.NoError(t, err)
+		s.Commit("feature2 local-only change")
+
+		branches := engine.BranchesOf(
+			s.Engine.GetBranch("feature1"),
+			s.Engine.GetBranch("feature2"),
+		)
+		statuses := s.Engine.ReadBranchRemoteStatuses(context.Background(), branches)
+
+		for _, branchName := range []string{"feature1", "feature2"} {
+			status := statuses[branchName]
+			require.False(t, status.Matches(), "branch %s should have diverged from remote", branchName)
+			require.NotEmpty(t, status.CommonAncestor, "branch %s should have a common ancestor with remote", branchName)
+			require.NotEqual(t, status.LocalSha, status.CommonAncestor, "branch %s local sha should be ahead of the common ancestor", branchName)
+			require.Equal(t, status.RemoteSha, status.CommonAncestor, "branch %s common ancestor should be the pushed remote sha", branchName)
+		}
+	})
 }
 
 func TestTrunkRemoteState(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ReadBranchRemoteStatuses` batches the cheap local/remote SHA lookups (`BatchGetRevisions`, one `FetchRemoteShas` call) but then computed each diverged branch's common ancestor **serially**, spawning one `git merge-base` subprocess per branch (`GetMergeBaseByRef`), plus a per-branch `GetRemoteRevision` fallback call.
- This function backs many hot paths: `sync`, `submit`, merge planning, branch cleanup, `lock`, and the `/api/v1/branches` and `/api/v1/view` HTTP handlers — so the serial cost scales with every diverged branch on every call.
- Mirrors the bounded worker-pool pattern already established one file over in `batchByBranch` (`internal/engine/branch_view.go`): resolve the batched fields first, then run the per-branch work through `utils.Run` (bounded to `GOMAXPROCS` workers), writing into a pre-sized slice by index before assembling the result map serially. Each worker only writes its own index, so no locking is needed.
- Added a test (`computes common ancestor for multiple diverged branches concurrently`) covering multiple diverged branches in a single call, since existing coverage only exercised single-branch and non-diverged cases.

## Test plan

- [x] `go test ./internal/engine/...` (full package)
- [x] `go test ./internal/engine/... -run TestReadBranchRemoteStatuses -race -v` (new + existing subtests, race detector clean)
- [x] `go vet ./internal/engine/...`
- [x] `gofmt -l` on changed files (no output)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FnyStpofERHkYgQunep1J)_