### PR TITLE
refactor: remove dead StackGraph depth-query methods

### DIFF
--- a/internal/engine/stack_graph.go
+++ b/internal/engine/stack_graph.go
@@ -239,16 +239,6 @@ func (g *StackGraph) IsDescendant(branch Branch, potentialDescendant Branch) boo
 	return false
 }
 
-// GetBranchesByDepth returns a map from depth to branch names at that depth.
-// This is useful for parallel operations where branches at the same depth are independent.
-func (g *StackGraph) GetBranchesByDepth() map[int][]string {
-	byDepth := make(map[int][]string)
-	for _, group := range g.DepthGroups() {
-		byDepth[group.Depth] = group.Branches.Names()
-	}
-	return byDepth
-}
-
 // DepthGroups returns the graph's branches grouped by depth in traversal order.
 func (g *StackGraph) DepthGroups() []DepthGroup {
 	if len(g.nodes) == 0 {
@@ -432,47 +422,6 @@ func (g *StackGraph) isAncestorOf(ancestor, descendant string) bool {
 		current = node.Parent
 	}
 	return false
-}
-
-// ForEachDepth iterates over branches grouped by depth, calling fn for each depth level.
-// The function receives the depth (0 = trunk level) and branches at that depth.
-// If fn returns an error, iteration stops and that error is returned.
-// Branches at the same depth can be processed in parallel by fn.
-// This is useful for operations like restacking where parents must complete before children.
-func (g *StackGraph) ForEachDepth(fn func(depth int, branches Branches) error) error {
-	for group := range g.DepthGroupsSeq() {
-		if err := fn(group.Depth, group.Branches); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// MaxDepth returns the maximum depth in the graph.
-// Returns -1 if the graph is empty.
-func (g *StackGraph) MaxDepth() int {
-	maxDepth := -1
-	for _, node := range g.nodes {
-		if node.Depth > maxDepth {
-			maxDepth = node.Depth
-		}
-	}
-	return maxDepth
-}
-
-// BranchesAtDepth returns all branches at the specified depth.
-// Returns nil if no branches exist at that depth.
-func (g *StackGraph) BranchesAtDepth(depth int) Branches {
-	var branches []Branch
-	for _, node := range g.nodes {
-		if node.Depth == depth {
-			branches = append(branches, node.Branch)
-		}
-	}
-	if len(branches) == 0 {
-		return nil
-	}
-	return NewBranches(branches)
 }
 
 // Upstack returns children of the branch (upstack).

--- a/internal/engine/stack_graph_test.go
+++ b/internal/engine/stack_graph_test.go
@@ -1,7 +1,6 @@
 package engine_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -209,7 +208,7 @@ func TestStackGraphIsRelated(t *testing.T) {
 	})
 }
 
-func TestStackGraphForEachDepth(t *testing.T) {
+func TestStackGraphDepthGroups(t *testing.T) {
 	t.Parallel()
 
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
@@ -222,18 +221,6 @@ func TestStackGraphForEachDepth(t *testing.T) {
 		})
 
 	graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
-
-	t.Run("iterates depths in order", func(t *testing.T) {
-		t.Parallel()
-
-		depthOrder := []int{}
-		err := graph.ForEachDepth(func(depth int, _ engine.Branches) error {
-			depthOrder = append(depthOrder, depth)
-			return nil
-		})
-		require.NoError(t, err)
-		require.Equal(t, []int{0, 1, 2, 3}, depthOrder)
-	})
 
 	t.Run("DepthGroups exposes named grouped traversal", func(t *testing.T) {
 		t.Parallel()
@@ -258,90 +245,5 @@ func TestStackGraphForEachDepth(t *testing.T) {
 		}
 
 		require.Equal(t, []int{0, 1}, seen)
-	})
-
-	t.Run("branches at same depth are independent", func(t *testing.T) {
-		t.Parallel()
-
-		branchesAtDepth1 := []string{}
-		err := graph.ForEachDepth(func(depth int, branches engine.Branches) error {
-			if depth == 1 {
-				branchesAtDepth1 = branches.Names()
-			}
-			return nil
-		})
-		require.NoError(t, err)
-		require.ElementsMatch(t, []string{"a", "b"}, branchesAtDepth1)
-	})
-
-	t.Run("stops on error", func(t *testing.T) {
-		t.Parallel()
-
-		testErr := errors.New("test error")
-		callCount := 0
-		err := graph.ForEachDepth(func(depth int, _ engine.Branches) error {
-			callCount++
-			if depth == 1 {
-				return testErr
-			}
-			return nil
-		})
-		require.ErrorIs(t, err, testErr)
-		require.Equal(t, 2, callCount) // depth 0 and 1
-	})
-}
-
-func TestStackGraphMaxDepth(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns max depth", func(t *testing.T) {
-		t.Parallel()
-
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
-			WithStack(map[string]string{
-				"a":  "main",
-				"a1": "a",
-				"a2": "a1",
-			})
-
-		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
-		require.Equal(t, 3, graph.MaxDepth())
-	})
-
-	t.Run("returns -1 for empty graph", func(t *testing.T) {
-		t.Parallel()
-
-		// Empty graph by filtering out everything
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, func(engine.Branch) bool {
-			return false
-		})
-		require.Equal(t, -1, graph.MaxDepth())
-	})
-}
-
-func TestStackGraphBranchesAtDepth(t *testing.T) {
-	t.Parallel()
-
-	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
-		WithStack(map[string]string{
-			"a":  "main",
-			"b":  "main",
-			"a1": "a",
-		})
-
-	graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
-
-	t.Run("returns branches at depth 1", func(t *testing.T) {
-		t.Parallel()
-		branches := graph.BranchesAtDepth(1)
-		names := branches.Names()
-		require.ElementsMatch(t, []string{"a", "b"}, names)
-	})
-
-	t.Run("returns nil for non-existent depth", func(t *testing.T) {
-		t.Parallel()
-		branches := graph.BranchesAtDepth(100)
-		require.Nil(t, branches)
 	})
 }


### PR DESCRIPTION
## Summary

- Removes four exported `StackGraph` methods — `GetBranchesByDepth`, `ForEachDepth`, `MaxDepth`, `BranchesAtDepth` — that have no production callers anywhere in the codebase.
- Every real depth-ordered consumer (`sync`, `restack`, etc.) already goes through `DepthGroups`/`DepthGroupsSeq` directly, or, in the case of the rebase validator, builds its own level structure independently. These four methods were exercised only by their own dedicated unit tests, not by any actual call site.
- Trims `stack_graph_test.go` down to the `DepthGroups`/`DepthGroupsSeq` coverage that real callers rely on, and drops the now-unused `errors` import.

Verified via repo-wide search that each removed symbol had zero references outside its own definition and its own dedicated test.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/engine/...`
- [x] `gofmt -l` on changed files (clean)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017VZST9PsKxygXZTGuQaqA3)_