### PR TITLE
perf(engine): resolve FindBranchesForCommits via BatchCommits

### DIFF
--- a/docs/plans/perf/absorb.md
+++ b/docs/plans/perf/absorb.md
@@ -78,10 +78,11 @@ After absorb, only the modified branches and their descendants have changed. A `
 
 `absorb.go:121–130` calls `GetAllCommits(SHA)` per branch and then walks. One `git rev-list --boundary <trunk>..<current>` returns all SHAs in one process. The per-branch attribution can be done from the parent-revision metadata already in the cache.
 
-> Note: the separate target→branch attribution step (`FindBranchesForCommits`,
-> `engine_reader.go:201`) *also* calls `GetAllCommits` per branch. If win #4
-> builds a `commitSHA → branchName` map during the single rev-list walk, that
-> batched scan can be dropped too — folding former win #5 into this one.
+> **Status:** Partly done. The separate target→branch attribution step
+> (`FindBranchesForCommits`, `engine_reader.go:205`) now resolves via
+> `BatchCommits` instead of calling `GetAllCommits` per branch. The downstack
+> loop at `absorb.go:121–130` this section describes is unchanged and still the
+> remaining win.
 
 ## Validation
 

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -198,10 +198,9 @@ func (e *engineImpl) FindMostRecentTrackedAncestors(ctx context.Context, branchN
 
 // FindBranchesForCommits maps each requested commit SHA to the tracked branch
 // that owns it (the branch whose parent..tip range contains the commit). It
-// scans each branch at most once, so the cost is O(branches) git-log
-// invocations regardless of how many SHAs are requested — the batch counterpart
-// to looking up commits one at a time. Commits not owned by any branch are
-// simply absent from the returned map.
+// resolves every branch's commits in one batched, cache-backed pass
+// (BatchCommits) rather than scanning branches one at a time. Commits not
+// owned by any branch are simply absent from the returned map.
 func (e *engineImpl) FindBranchesForCommits(commitSHAs []string) map[string]string {
 	result := make(map[string]string, len(commitSHAs))
 	if len(commitSHAs) == 0 {
@@ -218,15 +217,9 @@ func (e *engineImpl) FindBranchesForCommits(commitSHAs []string) map[string]stri
 	copy(branches, e.state.branches)
 	e.mu.RUnlock()
 
+	commitsByBranch := e.BatchCommits(BranchesFromNames(e, branches), CommitFormatSHA)
 	for _, branchName := range branches {
-		if len(result) == len(want) {
-			break
-		}
-		commits, err := e.GetAllCommits(NewBranch(branchName, e), CommitFormatSHA)
-		if err != nil {
-			continue
-		}
-		for _, sha := range commits {
+		for _, sha := range commitsByBranch[branchName] {
 			if _, ok := want[sha]; !ok {
 				continue
 			}


### PR DESCRIPTION
## Summary
- `FindBranchesForCommits` scanned every tracked branch with a serial `GetAllCommits` call per branch (one `git log` subprocess each) — exactly the N+1 pattern `.claude/rules/code-style.md` calls out (`GetAllCommits` in a loop → `BatchCommits`).
- `absorb` calls this on every run to attribute staged hunks to their owning branch, so the cost scales with stack size.
- Switch to `BatchCommits`, which resolves the same commit ranges (identical divergence-point base logic, verified against `GetAllCommits`) for all branches in one bounded-parallel pass instead of a serial scan.
- Updated `docs/plans/perf/absorb.md`, which had already flagged this exact spot as pending work, to reflect the fix.

I checked for other multi-branch loops calling `GetAllCommits` (`rg 'GetAllCommits\('`); the other call sites are all single-branch reads already, so this was the one spot the pattern applied.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/...`
- [x] `go test ./internal/actions/absorb/...`
- [x] `gofmt -l` clean on the changed file


---
_Generated by [Claude Code](https://claude.ai/code/session_01SvA8XXtvqFJnAhnwFwvrZE)_