### PR TITLE
ci: pin release and docker workflows to Go 1.26 too

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.26'
           cache: true
 
       - name: Set up Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.26'
           cache: true
           check-latest: true
 
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.26'
           cache: true
           check-latest: true
 
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.26'
           cache: true
 
       - name: Set up Node


### PR DESCRIPTION

The test-workflow pin missed the same problem in release.yml, which runs
the same pinned golangci-lint v2.11.3 under `go-version: 'stable'`. Once
setup-go's `check-latest` picks up Go 1.27, that lint job panics
type-checking 1.27-compiled packages exactly like the Test workflow's
did. It just doesn't show up on PRs because release.yml only runs on
tags.

Pin all three release.yml entries plus docker-main.yml, so every
workflow tracks the latest 1.26.x patch and matches go.mod's `go 1.26.0`
and mise.toml's `go = "1.26"`. This also stops goreleaser from building
shipped binaries with an untested Go major.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1695**
  * **PR #1696** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->