### PR TITLE
chore(ci): update golangci-lint to 2.13.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.11.3
+          version: v2.13.1
           args: --timeout=5m
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.11.3
+          version: v2.13.1
           args: --timeout=5m
 
   build:

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -17,6 +17,9 @@ import (
 	"github.com/getstackit/stackit/internal/utils"
 )
 
+// msgSubmitFailed is the completion message for a failed submit.
+const msgSubmitFailed = "Submit failed"
+
 // Options contains options for the submit command
 type Options struct {
 	Branch               string
@@ -301,7 +304,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if opts.CreateGitHubStack {
 			if err := publishGitHubStackMetadata(ctx, branchObjs, handler); err != nil {
 				if explicitGitHubStack {
-					handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+					handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: msgSubmitFailed})
 					return fmt.Errorf("PRs are already up to date, but creating native GitHub Stack metadata failed: %w", err)
 				}
 				handler.OnEvent(GitHubStackSkippedEvent{Reason: err.Error()})
@@ -411,7 +414,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	if submitErr != nil {
-		handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+		handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: msgSubmitFailed})
 		return submitErr
 	}
 
@@ -435,14 +438,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Push metadata refs for successfully submitted branches
 	if err := pushMetadataRefs(ctx, branchObjs); err != nil {
-		handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+		handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: msgSubmitFailed})
 		return fmt.Errorf("failed to push metadata to remote: %w. Your PRs were created/updated successfully, but metadata sync failed. Run 'st sync' and try submitting again", err)
 	}
 
 	if opts.CreateGitHubStack {
 		if err := publishGitHubStackMetadata(ctx, branchObjs, handler); err != nil {
 			if explicitGitHubStack {
-				handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: "Submit failed"})
+				handler.OnEvent(CompletionEvent{Outcome: OutcomeFailed, Message: msgSubmitFailed})
 				return fmt.Errorf("PRs were submitted successfully, but creating native GitHub Stack metadata failed: %w", err)
 			}
 			// Every PR already landed. Reporting the run as failed would exit

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ pnpm = "10.32.1"
 # Pinned (not "latest") so local matches CI exactly — a drift here means lint
 # passes locally but fails in CI (or vice versa). Keep in sync with the
 # golangci-lint-action version in .github/workflows/{test,release}.yml.
-golangci-lint = "2.11.3"
+golangci-lint = "2.13.1"
 
 # Development tools
 "aqua:watchexec/watchexec" = "latest"   # File watcher for dev auto-reload


### PR DESCRIPTION

v2.11.3 is built with go1.26 and panics parsing go1.27 sources, which is
what CI resolves to when a workflow floats on "stable". 2.13.1 handles
go1.27. The new version also flags a repeated "Submit failed" literal, so
extract it as a constant.