### PR TITLE
perf: batch stack view/status reads across all stacks instead of per-stack

### DIFF
--- a/internal/api/handlers/stacks.go
+++ b/internal/api/handlers/stacks.go
@@ -50,9 +50,21 @@ func (h *StacksHandler) listStacks(w http.ResponseWriter, entry *registry.RepoEn
 
 	graph := entry.Engine.Graph(engine.SortStrategySmart)
 
+	// One restack-status pass for every stack combined, instead of one per
+	// stack.
+	branchCount := 0
+	for _, stack := range stacks {
+		branchCount += len(stack.AllBranches)
+	}
+	allBranches := make(engine.Branches, 0, branchCount)
+	for _, stack := range stacks {
+		allBranches = append(allBranches, graph.BranchesByNames(stack.AllBranches)...)
+	}
+	statuses := entry.Engine.ReadBranchStatuses(allBranches)
+
 	summaries := make([]httpcontract.StackSummary, 0, len(stacks))
 	for _, stack := range stacks {
-		summary := httpcontract.MapStackSummary(entry.Engine, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, "")
+		summary := httpcontract.MapStackSummary(entry.Engine, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, "", statuses)
 		summaries = append(summaries, summary)
 	}
 
@@ -85,6 +97,7 @@ func (h *StacksHandler) getStack(w http.ResponseWriter, r *http.Request, entry *
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), found.AllBranches)
 	}
 
-	detail := httpcontract.MapStackDetail(r.Context(), entry.Engine, graph, found.RootBranch, found.AllBranches, found.PRCount, found.Scope, checksMap)
+	data := httpcontract.BatchReadStackData(r.Context(), entry.Engine, graph.BranchesByNames(found.AllBranches))
+	detail := httpcontract.MapStackDetail(entry.Engine, graph, found.RootBranch, found.AllBranches, found.PRCount, found.Scope, checksMap, data)
 	writeJSON(w, detail)
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -95,9 +95,22 @@ func (a *ViewAssembler) mapStackDetails(
 	stacks []merge.MultiStackInfo,
 	checksMap github.ChecksByBranch,
 ) []httpcontract.StackDetail {
+	// One remote listing, one stats pass, one commits pass, one commit-info
+	// pass, and one restack-status pass for every stack combined, instead of
+	// one of each per stack (ReadBranchRemoteStatuses alone is a network call).
+	branchCount := 0
+	for _, stack := range stacks {
+		branchCount += len(stack.AllBranches)
+	}
+	allBranches := make(engine.Branches, 0, branchCount)
+	for _, stack := range stacks {
+		allBranches = append(allBranches, graph.BranchesByNames(stack.AllBranches)...)
+	}
+	data := httpcontract.BatchReadStackData(ctx, a.eng, allBranches)
+
 	details := make([]httpcontract.StackDetail, 0, len(stacks))
 	for _, stack := range stacks {
-		detail := httpcontract.MapStackDetail(ctx, a.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
+		detail := httpcontract.MapStackDetail(a.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap, data)
 		details = append(details, detail)
 	}
 	return details

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -78,7 +78,10 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 }
 
 // MapStackSummary creates a StackSummary from stack discovery info.
-func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, owner string) StackSummary {
+// statuses should come from a single ReadBranchStatuses batch call covering
+// every branch across every stack in the request, not a call scoped to this
+// stack alone — see BatchReadStackData.
+func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, owner string, statuses engine.BranchStatuses) StackSummary {
 	currentBranch := eng.CurrentBranchName()
 	isCurrent := slices.Contains(allBranches, currentBranch)
 
@@ -96,15 +99,6 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		}
 	}
 
-	// Compute stack status using display branches (anchor excluded). Parent
-	// revisions are resolved in one batch call instead of one per branch.
-	displayBranchObjs := make(engine.Branches, 0, len(displayBranches))
-	for _, name := range displayBranches {
-		if node := graph.GetNode(name); node != nil {
-			displayBranchObjs = append(displayBranchObjs, node.Branch)
-		}
-	}
-	statuses := eng.ReadBranchStatuses(displayBranchObjs)
 	status := computeStackStatus(graph, displayBranches, statuses)
 
 	// Title and description come exclusively from explicit stack descriptions
@@ -131,8 +125,34 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 	}
 }
 
-// MapStackDetail creates a full StackDetail with all branch info.
-func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, checksMap github.ChecksByBranch) StackDetail {
+// BranchBatchData holds status/stat data for a set of branches, read in one
+// batch pass per field. Callers with multiple stacks should compute this once
+// over the union of every stack's branches and reuse it across every
+// MapStackDetail/MapStackSummary call, instead of computing it per stack.
+type BranchBatchData struct {
+	RemoteStatuses     engine.BranchRemoteStatuses
+	Stats              map[string]engine.BranchStat
+	CommitsByBranch    map[string][]string
+	CommitInfoByBranch map[string]git.CommitInfo
+	Statuses           engine.BranchStatuses
+}
+
+// BatchReadStackData reads remote status, stats, commits, commit info, and
+// restack status for branches in one batch call per field.
+func BatchReadStackData(ctx context.Context, eng engine.BranchReader, branches engine.Branches) BranchBatchData {
+	return BranchBatchData{
+		RemoteStatuses:     eng.ReadBranchRemoteStatuses(ctx, branches),
+		Stats:              eng.BatchBranchStats(branches),
+		CommitsByBranch:    eng.BatchCommits(branches, engine.CommitFormatReadableWithDate),
+		CommitInfoByBranch: eng.BatchCommitInfo(branches),
+		Statuses:           eng.ReadBranchStatuses(branches),
+	}
+}
+
+// MapStackDetail creates a full StackDetail with all branch info. data should
+// come from BatchReadStackData covering every branch across every stack in
+// the request — see BranchBatchData.
+func MapStackDetail(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, checksMap github.ChecksByBranch, data BranchBatchData) StackDetail {
 	// Derive owner from root branch's PR author
 	var owner string
 	if checksMap != nil {
@@ -141,40 +161,27 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		}
 	}
 
-	summary := MapStackSummary(eng, graph, rootBranch, allBranches, prCount, scope, owner)
+	summary := MapStackSummary(eng, graph, rootBranch, allBranches, prCount, scope, owner, data.Statuses)
 
 	// Check if root is a worktree anchor to filter it from branches
 	isAnchor := summary.HasWorktree
 	anchorName := rootBranch
 
 	nodes := make([]*engine.StackNode, 0, len(allBranches))
-	stackBranches := make(engine.Branches, 0, len(allBranches))
 	for _, name := range allBranches {
 		if isAnchor && name == anchorName {
 			continue
 		}
-		node := graph.GetNode(name)
-		if node == nil {
-			continue
+		if node := graph.GetNode(name); node != nil {
+			nodes = append(nodes, node)
 		}
-		nodes = append(nodes, node)
-		stackBranches = append(stackBranches, node.Branch)
 	}
-
-	// One remote listing, one stats pass, one commits pass, one commit-info
-	// pass, and one restack-status pass for the whole stack instead of one of
-	// each per branch.
-	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, stackBranches)
-	stats := eng.BatchBranchStats(stackBranches)
-	commitsByBranch := eng.BatchCommits(stackBranches, engine.CommitFormatReadableWithDate)
-	commitInfoByBranch := eng.BatchCommitInfo(stackBranches)
-	statuses := eng.ReadBranchStatuses(stackBranches)
 
 	branches := make([]BranchResponse, 0, len(nodes))
 	for _, node := range nodes {
 		name := node.Branch.GetName()
 		checks := checksMap.Get(name)
-		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name], commitInfoByBranch[name], !statuses.IsUpToDate(node.Branch))
+		br := MapBranch(eng, node.Branch, node, checks, data.RemoteStatuses.ForBranch(node.Branch), data.Stats[name], data.CommitsByBranch[name], data.CommitInfoByBranch[name], !data.Statuses.IsUpToDate(node.Branch))
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {

--- a/internal/engine/stack_graph.go
+++ b/internal/engine/stack_graph.go
@@ -180,6 +180,18 @@ func (g *StackGraph) Node(branch Branch) *StackNode {
 	return g.nodes[branch.GetName()]
 }
 
+// BranchesByNames resolves branch names to their Branch objects via the
+// graph, skipping any name with no node.
+func (g *StackGraph) BranchesByNames(names []string) Branches {
+	branches := make(Branches, 0, len(names))
+	for _, name := range names {
+		if node := g.GetNode(name); node != nil {
+			branches = append(branches, node.Branch)
+		}
+	}
+	return branches
+}
+
 // CurrentBranch returns the name of the currently checked-out branch.
 func (g *StackGraph) CurrentBranch() string {
 	return g.current


### PR DESCRIPTION
## Summary

- `GET /view` and `GET /stacks` each looped over every discovered stack, calling `MapStackDetail`/`MapStackSummary` once per stack. Those mappers internally called `ReadBranchRemoteStatuses`, `BatchBranchStats`, `BatchCommits`, `BatchCommitInfo`, and `ReadBranchStatuses` — so a repo with N stacks made N separate batch-read passes instead of one covering every branch in the request.
- `ReadBranchRemoteStatuses` issues a network `git ls-remote` call, so this multiplied network round-trips by stack count on a path the web UI polls on initial load and every SSE-triggered refresh (`apps/web/src/components/providers/repo-provider.tsx`).
- Hoisted the batch reads to the caller (`ViewAssembler.mapStackDetails` and the stacks handler) so they run once over the union of branches across all stacks, and threaded the results into `MapStackDetail`/`MapStackSummary` via a new `BranchBatchData` struct (`internal/contracts/http/mappers.go`). Added a small `StackGraph.BranchesByNames` helper to resolve branch names to `Branch` objects, used by all three call sites.
- Behavior is unchanged — each of the underlying batch reads already computes results independently per branch, so widening the input set to cover every stack's branches doesn't change any individual branch's result, just avoids redundant passes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/contracts/... ./internal/api/... ./internal/engine/...`
- [x] `go test ./internal/contracts/... ./internal/api/... ./internal/engine/...` (all pass)
- [x] `gofmt -l` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_013WrEuy1YfeT1XiUFy6QYHr)_