### PR TITLE
perf(git): read HEAD directly for GetCurrentRevision in detached HEAD

### DIFF
--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -49,6 +49,52 @@ func (r *runner) readHeadBranch() (string, bool) {
 	return name, true
 }
 
+// readHeadRevision reads the commit HEAD points at straight out of the HEAD
+// file when HEAD is detached, the same way readHeadBranch fast-paths the
+// on-a-branch case. Detached HEAD is exactly the state worktree-based
+// rebases, restacks, and validation runs are required to leave HEAD in (see
+// safety-invariants.md, "Worktree Operations Must Use Detached HEAD"), so
+// `git rev-parse --verify HEAD` runs once per branch touched in every one of
+// those operations.
+//
+// Reports ok=false for anything other than a raw SHA (HEAD on a branch, an
+// unreadable file, malformed content). The caller then runs the real
+// command, so git stays the authority on every case except detached HEAD.
+func (r *runner) readHeadRevision() (string, bool) {
+	if err := r.ensureRepo(); err != nil {
+		return "", false
+	}
+	gitDir := r.getGitDir(context.Background())
+	if gitDir == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return "", false
+	}
+	sha := strings.TrimSpace(string(data))
+	if !isHexSHA(sha) {
+		return "", false
+	}
+	return sha, true
+}
+
+// isHexSHA reports whether s looks like a full SHA-1 (40 hex chars) or
+// SHA-256 (64 hex chars) object id.
+func isHexSHA(s string) bool {
+	switch len(s) {
+	case 40, 64:
+	default:
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
 // ResolveBranchNameCase reconciles a branch name reported by HEAD with the
 // casing the ref actually carries in refs/heads.
 //

--- a/internal/git/current_revision_test.go
+++ b/internal/git/current_revision_test.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GetCurrentRevision reads HEAD off disk instead of spawning `git rev-parse
+// --verify HEAD` when HEAD is detached, so these cases pin that the fast
+// path agrees with git and that the states it deliberately does not handle
+// still fall through to git.
+func TestGetCurrentRevision(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+		return string(out)
+	}
+
+	newRepo := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		run(t, dir, "init", "-b", "main")
+		run(t, dir, "config", "user.email", "t@example.com")
+		run(t, dir, "config", "user.name", "t")
+		run(t, dir, "commit", "--allow-empty", "-m", "init")
+		return dir
+	}
+
+	revParse := func(t *testing.T, dir string) string {
+		t.Helper()
+		out := run(t, dir, "rev-parse", "HEAD")
+		return out[:len(out)-1] // trim trailing newline
+	}
+
+	t.Run("detached HEAD", func(t *testing.T) {
+		t.Parallel()
+		dir := newRepo(t)
+		run(t, dir, "checkout", "--detach")
+
+		rev, err := NewRunnerWithPath(dir, nil).GetCurrentRevision(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, revParse(t, dir), rev)
+	})
+
+	t.Run("on a branch falls back to git", func(t *testing.T) {
+		t.Parallel()
+		dir := newRepo(t)
+		run(t, dir, "checkout", "-b", "feature")
+
+		rev, err := NewRunnerWithPath(dir, nil).GetCurrentRevision(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, revParse(t, dir), rev)
+	})
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -740,6 +740,9 @@ func (r *runner) GetRemoteRevision(branchName string) (string, error) {
 }
 
 func (r *runner) GetCurrentRevision(ctx context.Context) (string, error) {
+	if sha, ok := r.readHeadRevision(); ok {
+		return sha, nil
+	}
 	out, err := r.RunGitCommandWithContext(ctx, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve HEAD: %w", err)


### PR DESCRIPTION
## Summary

- Adds a `readHeadRevision` fast path to `GetCurrentRevision` that reads the SHA straight out of the worktree's `HEAD` file when HEAD is detached, skipping the `git rev-parse --verify HEAD` subprocess spawn.
- Mirrors the existing `GetCurrentBranch` fast path (#1686, `readHeadBranch`), which took the same approach for the on-a-branch case and was measured at ~15% of all subprocess spawns in the integration suite.
- Detached HEAD is exactly the state worktree-based rebases, restacks, absorb, and validation runs are required to leave HEAD in (see `.claude/rules/safety-invariants.md`, "Worktree Operations Must Use Detached HEAD"), so `GetCurrentRevision` is called once per branch touched in every one of those operations (`internal/git/rebase.go`, `internal/git/cherry_pick.go`, `internal/engine/restack_impl.go`, `internal/engine/engine_sync.go`, `internal/engine/engine_absorb.go`, `internal/engine/rebase_validator.go`).
- Falls back to the existing `git rev-parse` call for every other case (HEAD on a branch, unreadable file, malformed content), so git stays authoritative there.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/git/...`
- [x] `go test ./internal/git/...` (includes new `TestGetCurrentRevision` covering detached HEAD and on-a-branch fallback)
- [x] `gofmt -l` on changed files (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_014pnRzfXVDzMd8NFAEbh6rc)_