### PR TITLE
perf: batch remote SHA fallback in ReadBranchRemoteStatuses

### DIFF
--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -263,6 +263,19 @@ func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Bran
 		remoteShas = map[string]string{}
 	}
 
+	// Branches the remote listing did not cover fall back to the local
+	// remote-tracking ref. That is resolved in one batched call up front,
+	// before the parallel pass: it is a single git invocation for the whole
+	// set, so it must not be re-entered per worker.
+	var missingRefs []string
+	for _, branch := range branches {
+		branchName := branch.GetName()
+		if remoteShas[branchName] == "" {
+			missingRefs = append(missingRefs, remote+"/"+branchName)
+		}
+	}
+	fallbackShas, _ := e.git.BatchGetRevisions(missingRefs)
+
 	// Each worker writes only its own index, so the slice is filled without
 	// synchronization and assembled into the result map serially afterward,
 	// mirroring batchByBranch in branch_view.go.
@@ -281,9 +294,7 @@ func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Bran
 		localSha := localShas[branchName]
 		remoteSha := remoteShas[branchName]
 		if remoteSha == "" {
-			if sha, err := e.git.GetRemoteRevision(branchName); err == nil {
-				remoteSha = sha
-			}
+			remoteSha = fallbackShas[remote+"/"+branchName]
 		}
 
 		status := BranchRemoteStatus{

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -1339,6 +1339,45 @@ func TestReadBranchRemoteStatuses(t *testing.T) {
 			require.Equal(t, status.RemoteSha, status.CommonAncestor, "branch %s common ancestor should be the pushed remote sha", branchName)
 		}
 	})
+
+	t.Run("falls back to remote-tracking refs for branches the remote listing omits", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
+
+		// Two branches that ls-remote will not report, each with a stale
+		// remote-tracking ref left behind — the shape you get when the
+		// remote branch is gone but nothing has pruned locally yet. Both
+		// must resolve, not just the first: the fallback is one batched
+		// rev-parse, so a mapping bug there would surface as a branch
+		// silently reporting no remote at all.
+		for _, name := range []string{"feature1", "feature2"} {
+			s.Checkout("main")
+			s.CreateBranch(name).Commit(name + " change")
+
+			sha, err := s.Scene.Repo.GetRevision(name)
+			require.NoError(t, err)
+			require.NoError(t, s.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/"+name, sha))
+		}
+		s.Checkout("main")
+
+		branches := engine.BranchesOf(
+			s.Engine.GetBranch("feature1"),
+			s.Engine.GetBranch("feature2"),
+		)
+		statuses := s.Engine.ReadBranchRemoteStatuses(context.Background(), branches)
+
+		for _, branchName := range []string{"feature1", "feature2"} {
+			status := statuses[branchName]
+			require.NotEmpty(t, status.RemoteSha, "branch %s should resolve a remote sha from its tracking ref", branchName)
+			require.Equal(t, status.LocalSha, status.RemoteSha, "branch %s tracking ref should match local", branchName)
+			require.True(t, status.Matches(), "branch %s should match its tracking ref", branchName)
+		}
+	})
 }
 
 func TestTrunkRemoteState(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ReadBranchRemoteStatuses` fell back to `GetRemoteRevision` (one `git rev-parse` subprocess) per branch whenever `FetchRemoteShas` didn't have an entry for that branch — which is every branch when the single `ls-remote` call fails (offline, auth issue), and every not-yet-pushed branch even on success.
- `BatchGetRevisions` already exists and can resolve an arbitrary list of `"<remote>/<branch>"` refs in one `git rev-parse` invocation, matching the project's batch-API convention (`.claude/rules/code-style.md`).
- This function sits on hot, typically multi-branch paths (`submit`, dashboard/view assembly, branch cleanup, merge planning, sync, lock), so the fix turns an O(N) subprocess fan-out into O(1) on those paths, worst case on every command when offline.
- Behavior is unchanged: same fallback semantics and same graceful per-ref degradation, just batched into a single call instead of N.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/...`
- [x] `gofmt -l` / `go vet` on the changed file


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx1tr3bRJs3QN8D42iAR1H)_