### PR TITLE
perf(engine): stop UntrackedCollision from re-listing worktrees

### DIFF
--- a/internal/actions/worktree_holds.go
+++ b/internal/actions/worktree_holds.go
@@ -172,7 +172,7 @@ func branchWorktreeHoldReason(ctx *app.Context, branch, path string) string {
 	if hasChanges {
 		return restackWorktreeHoldReasonUncommittedChanges
 	}
-	if collides, known := eng.UntrackedCollision(ctx.Context, branch); collides || !known {
+	if collides, known := eng.UntrackedCollision(ctx.Context, branch, path); collides || !known {
 		if !known {
 			return restackWorktreeHoldReasonUntrackedCheckFailed
 		}

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -457,8 +457,10 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 	return false, nil, nil
 }
 
-// UntrackedCollision reports whether untracked files in the worktree holding
-// branchName would be destroyed by restacking it.
+// UntrackedCollision reports whether untracked files in worktreePath, the
+// worktree holding branchName, would be destroyed by restacking it. Callers
+// resolve worktreePath themselves (typically already have it in hand from
+// ListWorktrees) rather than having this re-list worktrees on every call.
 //
 // `git reset --hard` overwrites an untracked file only when the incoming commit
 // contains that same path; every other untracked file survives untouched. The
@@ -467,12 +469,7 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 //
 // known is false when the question could not be answered, which callers must
 // treat as unsafe rather than as "no collision".
-func (e *engineImpl) UntrackedCollision(ctx context.Context, branchName string) (collides, known bool) {
-	worktrees, err := e.git.ListWorktrees(ctx)
-	if err != nil {
-		return false, false
-	}
-	worktreePath := worktrees.PathForBranch(branchName)
+func (e *engineImpl) UntrackedCollision(ctx context.Context, branchName, worktreePath string) (collides, known bool) {
 	if worktreePath == "" {
 		return false, true
 	}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -288,7 +288,7 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
-	UntrackedCollision(ctx context.Context, branchName string) (collides, known bool)
+	UntrackedCollision(ctx context.Context, branchName, worktreePath string) (collides, known bool)
 	// WorktreeRebaseInProgress reports whether a rebase is active in worktreePath.
 	WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -75,7 +75,7 @@ func (e *engineImpl) branchWorktreeResetTarget(ctx context.Context, branchName s
 	// file was never in git, so there is no reflog or stash to recover it from.
 	// The batch path guards this through untrackedCollisionHold; this one-off
 	// path has to ask the same question.
-	switch collides, known := e.UntrackedCollision(ctx, branchName); {
+	switch collides, known := e.UntrackedCollision(ctx, branchName, worktreePath); {
 	case !known:
 		return worktreeResetDecision{HeldPath: worktreePath, HeldReason: "its untracked files could not be inspected"}
 	case collides:


### PR DESCRIPTION
## Summary
- `UntrackedCollision` re-derived a branch's worktree path by spawning its own `git worktree list` subprocess, even though both call sites already had the worktree path in hand from a `ListWorktrees` call at the top of the same function.
- `restack_impl.go`'s `branchWorktreeResetTarget` already computes `worktreePath` before calling `UntrackedCollision`, and `worktree_holds.go`'s `branchWorktreeHoldReason` already receives `path` as a parameter (from a `ListWorktrees` call one level up, in a loop over every worktree in the repo).
- This mirrors a redundancy the batch restack path (`untrackedCollisionHold`) already avoids by reusing a pre-fetched worktree snapshot — the comment above it even says "The batch path guards this through `untrackedCollisionHold`," implying this one-off path was simply never updated to match.

## Change
`UntrackedCollision` now takes `worktreePath` as a parameter instead of re-listing worktrees to derive it itself. Both call sites pass through the path they already have. Purely mechanical, behavior-preserving — no observable change, just one fewer `git worktree list` subprocess spawn per call.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/...`
- [x] `go test ./internal/actions/...`


---
_Generated by [Claude Code](https://claude.ai/code/session_012Da9NM7xzAYnj7Dw6dtjcR)_