### PR TITLE
perf(merge): avoid O(n*m) scan when computing upstack branches to merge

### DIFF
--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -3,7 +3,6 @@ package merge
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -265,24 +264,20 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 
 	// 3. Identify upstack branches that need restacking (moved up for batch loading)
 	upstackBranches := []string{}
+	mergedMap := make(map[string]bool, len(allBranches))
+	for _, b := range allBranches {
+		mergedMap[b] = true
+	}
 	if opts.Scope != "" {
 		// In scope mode, find all tracked branches with the scope that are not being merged
 		for _, branch := range eng.AllBranches() {
-			if branch.IsTracked() && eng.GetScope(branch).String() == opts.Scope {
-				// Check if this branch is not already being merged
-				isBeingMerged := slices.Contains(allBranches, branch.GetName())
-				if !isBeingMerged {
-					upstackBranches = append(upstackBranches, branch.GetName())
-				}
+			if branch.IsTracked() && eng.GetScope(branch).String() == opts.Scope && !mergedMap[branch.GetName()] {
+				upstackBranches = append(upstackBranches, branch.GetName())
 			}
 		}
 	} else {
 		// For upstack branches, we want branches that are descendants of the current branch,
 		// but NOT in the list of branches we're merging.
-		mergedMap := make(map[string]bool)
-		for _, b := range allBranches {
-			mergedMap[b] = true
-		}
 
 		// Only get upstack of the current branch (the top of the stack being merged)
 		upstack := graph.Range(eng.GetBranch(planCurrentBranch), engine.StackRange{RecursiveChildren: true})


### PR DESCRIPTION
## Summary

- `CollectMergeBranches` (`internal/actions/merge/plan.go`) computes which upstack branches need restacking after a merge. In scope mode, it looped over every branch in the repo and called `slices.Contains(allBranches, branch.GetName())` for each one — an O(n·m) rescan of `allBranches` per candidate branch.
- The non-scope branch immediately below already builds a `mergedMap` for O(1) membership checks instead. Hoisted that map above the `if opts.Scope != ""` split so both branches share it, removing the duplicate linear scan and the now-unused `slices` import.
- No behavior change — same branches are selected, just without the repeated re-scan.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/merge/...`
- [x] `go test ./internal/actions/merge/...` (passes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JMo1RgPkXCrKwaAmXrk6XM)_