### PR TITLE
refactor(navigation): dedupe flattenThroughAnchors helper

### DIFF
--- a/internal/actions/navigation/action.go
+++ b/internal/actions/navigation/action.go
@@ -103,7 +103,7 @@ func traverseUpward(currentBranch string, ctx *app.Context, graph *engine.StackG
 	children := graph.ChildBranches(ctx.Engine.GetBranch(currentBranch))
 
 	// Filter out worktree anchors, but include their children
-	children = flattenThroughAnchors(children, graph)
+	children = FlattenThroughAnchors(children, graph)
 
 	if len(children) == 0 {
 		// No children, we're at the tip
@@ -128,14 +128,14 @@ func traverseUpward(currentBranch string, ctx *app.Context, graph *engine.StackG
 	return traverseUpward(nextBranch, ctx, graph, handler)
 }
 
-// flattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
-func flattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
+// FlattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
+func FlattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
 	result := engine.Branches{}
 	for _, b := range branches {
 		if b.IsWorktreeAnchor() {
 			// Replace anchor with its children (recursively flatten)
 			grandchildren := graph.ChildBranches(b)
-			result = result.Concat(flattenThroughAnchors(grandchildren, graph))
+			result = result.Concat(FlattenThroughAnchors(grandchildren, graph))
 		} else {
 			result = result.Append(b)
 		}

--- a/internal/actions/navigation/action_test.go
+++ b/internal/actions/navigation/action_test.go
@@ -179,7 +179,7 @@ func TestFlattenThroughAnchorsPromotesGrandchildren(t *testing.T) {
 	trunk := s.Engine.Trunk()
 	children := graph.ChildBranches(trunk)
 
-	flattened := flattenThroughAnchors(children, graph)
+	flattened := FlattenThroughAnchors(children, graph)
 	names := make([]string, len(flattened))
 	for i, b := range flattened {
 		names[i] = b.GetName()

--- a/internal/cli/navigation/up.go
+++ b/internal/cli/navigation/up.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/navigation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/engine"
@@ -56,7 +57,7 @@ the --to flag is used to specify a target branch to navigate towards.`,
 				// Traverse up the specified number of steps
 				targetBranch := currentBranch.GetName()
 				for i := 0; i < steps; i++ {
-					children := flattenThroughAnchors(graph.ChildBranches(ctx.Engine.GetBranch(targetBranch)), graph)
+					children := navigation.FlattenThroughAnchors(graph.ChildBranches(ctx.Engine.GetBranch(targetBranch)), graph)
 					if len(children) == 0 {
 						if i == 0 {
 							ctx.Output.Info("Already at the top of the stack.")
@@ -127,20 +128,6 @@ the --to flag is used to specify a target branch to navigate towards.`,
 	_ = cmd.RegisterFlagCompletionFunc("to", common.CompleteBranches)
 
 	return cmd
-}
-
-// flattenThroughAnchors replaces worktree anchor branches with their non-anchor children.
-func flattenThroughAnchors(branches engine.Branches, graph *engine.StackGraph) engine.Branches {
-	result := engine.Branches{}
-	for _, b := range branches {
-		if b.IsWorktreeAnchor() {
-			grandchildren := graph.ChildBranches(b)
-			result = result.Concat(flattenThroughAnchors(grandchildren, graph))
-		} else {
-			result = result.Append(b)
-		}
-	}
-	return result
 }
 
 func promptForChild(children []string, parent string) (string, error) {


### PR DESCRIPTION
## Summary

- `flattenThroughAnchors` (the recursive helper that replaces worktree-anchor branches with their non-anchor children) was defined byte-for-byte identically in both `internal/actions/navigation/action.go` and `internal/cli/navigation/up.go`.
- Exported it as `FlattenThroughAnchors` from `internal/actions/navigation`, deleted the duplicate copy in `up.go`, and had `up.go` import it — the same pattern already used by sibling commands `top.go`/`bottom.go`, which import `internal/actions/navigation` for `SwitchBranchAction`.
- Behavior is unchanged; this only removes a maintenance hazard where a future fix to the recursion could be applied to one copy and silently missed in the other.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/actions/navigation/... ./internal/cli/navigation/...` — both pass, including the existing `TestFlattenThroughAnchorsPromotesGrandchildren` test (updated to call the now-exported name)
- [x] `go vet ./internal/actions/navigation/... ./internal/cli/navigation/...`
- [x] `gofmt -l` clean on touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5uRgedaXSY2EfZCTYiHBH)_