### PR TITLE
test: parallelize git package scene-based tests

### DIFF
--- a/internal/engine/engine_split_test.go
+++ b/internal/engine/engine_split_test.go
@@ -12,8 +12,11 @@ import (
 )
 
 func TestApplySplitToCommits(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates branches at specified commit points", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.BasicSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.BasicSceneSetup)
 		repo := scene.Repo
 
 		// Create a stack: main -> feature
@@ -98,13 +101,14 @@ func TestApplySplitToCommits(t *testing.T) {
 	})
 
 	t.Run("successfully applies split when branch ref is updated after new commits", func(t *testing.T) {
+		t.Parallel()
 		// This test simulates what split --by-hunk does:
 		// 1. Start with feature branch
 		// 2. Create new commits in detached HEAD (on top of main)
 		// 3. Update feature branch ref to point to the new tip
 		// 4. Apply split
 
-		scene := testhelpers.NewScene(t, testhelpers.BasicSceneSetup)
+		scene := testhelpers.NewSceneParallel(t, testhelpers.BasicSceneSetup)
 		repo := scene.Repo
 
 		// Trunk commit
@@ -162,7 +166,8 @@ func TestApplySplitToCommits(t *testing.T) {
 	})
 
 	t.Run("validates branch names and points match", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.BasicSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.BasicSceneSetup)
 		eng, err := engine.NewEngine(engine.Options{
 			RepoRoot: scene.Dir,
 			Trunk:    "main",
@@ -181,15 +186,18 @@ func TestApplySplitToCommits(t *testing.T) {
 	})
 
 	t.Run("fails when branch has no parent", func(t *testing.T) {
+		t.Parallel()
 		t.Skip("Requires engine with metadata setup")
 	})
 
 	t.Run("successfully applies split with valid inputs", func(t *testing.T) {
+		t.Parallel()
 		t.Skip("Requires full git repository and engine setup")
 	})
 
 	t.Run("creates sibling branches when AsSibling is true", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.BasicSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.BasicSceneSetup)
 		repo := scene.Repo
 
 		// Create a stack: main -> feature
@@ -259,7 +267,8 @@ func TestApplySplitToCommits(t *testing.T) {
 	})
 
 	t.Run("rejects sibling splits below a non-trunk branch in linear mode", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.BasicSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.BasicSceneSetup)
 		repo := scene.Repo
 
 		require.NoError(t, repo.CreateChangeAndCommit("main content", "mainfile"))
@@ -296,7 +305,8 @@ func TestApplySplitToCommits(t *testing.T) {
 	})
 
 	t.Run("sibling mode reparents children to last branch", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.BasicSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.BasicSceneSetup)
 		repo := scene.Repo
 
 		// Setup main
@@ -370,6 +380,8 @@ func TestApplySplitToCommits(t *testing.T) {
 // Test helper functions
 
 func TestContains(t *testing.T) {
+	t.Parallel()
+
 	// Test slices.Contains used in ApplySplitToCommits
 	require.True(t, slices.Contains([]string{"a", "b", "c"}, "b"))
 	require.False(t, slices.Contains([]string{"a", "b", "c"}, "d"))

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 func TestConfigStore_GetSet(t *testing.T) {
+	t.Parallel()
+
 	t.Run("sets and gets a string value", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -24,7 +27,8 @@ func TestConfigStore_GetSet(t *testing.T) {
 	})
 
 	t.Run("returns empty string for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -34,7 +38,8 @@ func TestConfigStore_GetSet(t *testing.T) {
 	})
 
 	t.Run("overwrites existing value", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -51,8 +56,11 @@ func TestConfigStore_GetSet(t *testing.T) {
 }
 
 func TestConfigStore_Bool(t *testing.T) {
+	t.Parallel()
+
 	t.Run("sets and gets true", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -65,7 +73,8 @@ func TestConfigStore_Bool(t *testing.T) {
 	})
 
 	t.Run("sets and gets false", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -78,7 +87,8 @@ func TestConfigStore_Bool(t *testing.T) {
 	})
 
 	t.Run("returns false for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -88,7 +98,8 @@ func TestConfigStore_Bool(t *testing.T) {
 	})
 
 	t.Run("GetBoolWithDefault returns default for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -100,7 +111,8 @@ func TestConfigStore_Bool(t *testing.T) {
 	})
 
 	t.Run("GetBoolWithDefault returns actual value when set", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -113,8 +125,11 @@ func TestConfigStore_Bool(t *testing.T) {
 }
 
 func TestConfigStore_Int(t *testing.T) {
+	t.Parallel()
+
 	t.Run("sets and gets positive integer", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -127,7 +142,8 @@ func TestConfigStore_Int(t *testing.T) {
 	})
 
 	t.Run("sets and gets zero", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -140,7 +156,8 @@ func TestConfigStore_Int(t *testing.T) {
 	})
 
 	t.Run("returns 0 for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -150,7 +167,8 @@ func TestConfigStore_Int(t *testing.T) {
 	})
 
 	t.Run("GetIntWithDefault returns default for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -159,7 +177,8 @@ func TestConfigStore_Int(t *testing.T) {
 	})
 
 	t.Run("GetIntWithDefault returns actual value when set", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -171,7 +190,8 @@ func TestConfigStore_Int(t *testing.T) {
 	})
 
 	t.Run("GetIntWithDefault returns 0 when explicitly set to 0", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -185,8 +205,11 @@ func TestConfigStore_Int(t *testing.T) {
 }
 
 func TestConfigStore_MultiValue(t *testing.T) {
+	t.Parallel()
+
 	t.Run("adds and gets multiple values", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -205,7 +228,8 @@ func TestConfigStore_MultiValue(t *testing.T) {
 	})
 
 	t.Run("returns nil for non-existent multi-value key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -216,8 +240,11 @@ func TestConfigStore_MultiValue(t *testing.T) {
 }
 
 func TestConfigStore_Unset(t *testing.T) {
+	t.Parallel()
+
 	t.Run("removes existing key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -233,7 +260,8 @@ func TestConfigStore_Unset(t *testing.T) {
 	})
 
 	t.Run("does not error for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -242,7 +270,8 @@ func TestConfigStore_Unset(t *testing.T) {
 	})
 
 	t.Run("removes all values for multi-value key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -262,8 +291,11 @@ func TestConfigStore_Unset(t *testing.T) {
 }
 
 func TestConfigStore_Exists(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns true for existing key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 
@@ -274,7 +306,8 @@ func TestConfigStore_Exists(t *testing.T) {
 	})
 
 	t.Run("returns false for non-existent key", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		store := git.NewConfigStore(scene.Dir)
 

--- a/internal/git/merge_base_test.go
+++ b/internal/git/merge_base_test.go
@@ -13,8 +13,11 @@ import (
 )
 
 func TestIsAncestor(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns true when commit is ancestor", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 		err := runner.InitDefaultRepo()
@@ -37,7 +40,8 @@ func TestIsAncestor(t *testing.T) {
 	})
 
 	t.Run("returns false when commit is not ancestor", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 		err := runner.InitDefaultRepo()
@@ -60,7 +64,8 @@ func TestIsAncestor(t *testing.T) {
 	})
 
 	t.Run("returns true when commits are the same", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 		err := runner.InitDefaultRepo()
@@ -77,6 +82,8 @@ func TestIsAncestor(t *testing.T) {
 }
 
 func TestIsAncestor_AfterFetch(t *testing.T) {
+	t.Parallel()
+
 	// This test verifies the runner can resolve and walk to a newly fetched
 	// commit. We test this by creating a scenario similar to a PR merge:
 	// 1. Local repo has main at commit A
@@ -85,8 +92,9 @@ func TestIsAncestor_AfterFetch(t *testing.T) {
 	// 4. IsAncestor should still resolve through `git merge-base --is-ancestor`
 
 	t.Run("works after fetch with fresh runner", func(t *testing.T) {
+		t.Parallel()
 		// 1. Setup a "remote" repository
-		remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		remoteScene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
 		require.NoError(t, err)
 		err = remoteScene.Repo.PushBranch("upstream", "main")
@@ -135,8 +143,9 @@ func TestIsAncestor_AfterFetch(t *testing.T) {
 	})
 
 	t.Run("works with diverged branches", func(t *testing.T) {
+		t.Parallel()
 		// Test that IsAncestor correctly returns false for diverged branches
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 		err := runner.InitDefaultRepo()

--- a/internal/git/merge_detection_test.go
+++ b/internal/git/merge_detection_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 func TestIsMerged(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns false for unmerged branch", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Create branch
 		err := scene.Repo.CreateAndCheckoutBranch("branch1")
@@ -35,7 +38,8 @@ func TestIsMerged(t *testing.T) {
 	})
 
 	t.Run("returns true for merged branch", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Create branch
 		err := scene.Repo.CreateAndCheckoutBranch("branch1")
@@ -59,7 +63,8 @@ func TestIsMerged(t *testing.T) {
 	})
 
 	t.Run("returns true for rebase-merged branch", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		err := scene.Repo.CreateAndCheckoutBranch("branch1")
 		require.NoError(t, err)
@@ -93,7 +98,8 @@ func TestIsMerged(t *testing.T) {
 	// IsSquashMerged can. This split keeps the expensive scan off the hot
 	// IsMerged path.
 	t.Run("multi-commit squash: IsMerged false, IsSquashMerged true", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		err := scene.Repo.CreateAndCheckoutBranch("branch1")
 		require.NoError(t, err)
@@ -150,7 +156,9 @@ func (l *captureGitLogger) countDebugContaining(needle string) int {
 }
 
 func TestIsSquashMergedCachesTargetCommitPatchIDs(t *testing.T) {
-	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 	err := scene.Repo.CreateAndCheckoutBranch("branch1")
 	require.NoError(t, err)

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -13,11 +13,13 @@ import (
 )
 
 func TestPullBranch_Reproduction(t *testing.T) {
+	t.Parallel()
+
 	// This test attempts to reproduce the "false conflict" where PullBranch
 	// returns PullConflict even though a fast-forward is possible.
 
 	// 1. Setup a "remote" repository
-	remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	remoteScene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
 	require.NoError(t, err)
 	err = remoteScene.Repo.PushBranch("upstream", "main")
@@ -86,12 +88,14 @@ func TestPullBranch_Reproduction(t *testing.T) {
 }
 
 func TestPullBranch_FetchFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
 	// Regression: a failed fetch against a remote that IS configured (e.g. a
 	// network/auth error, or here an unreachable URL) must surface as an
 	// error instead of silently falling through to UpdateBranchFromRemote,
 	// which only reads the (now stale) remote-tracking ref and can report
 	// PullUnneeded even though the branch was never actually synced.
-	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 	runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 	err := runner.InitDefaultRepo()
 	require.NoError(t, err)
@@ -105,10 +109,12 @@ func TestPullBranch_FetchFailureReturnsError(t *testing.T) {
 }
 
 func TestPullBranch_NoRemoteConfiguredReturnsUnneeded(t *testing.T) {
+	t.Parallel()
+
 	// Ephemeral setups (e.g. worktree sessions created without a remote)
 	// must NOT have "no remote configured" treated as a pull failure -
 	// UpdateBranchFromRemote already tolerates this via GetRemoteSha.
-	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 	runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 	err := runner.InitDefaultRepo()
 	require.NoError(t, err)
@@ -119,6 +125,8 @@ func TestPullBranch_NoRemoteConfiguredReturnsUnneeded(t *testing.T) {
 }
 
 func TestBranchFetchRefspec_ForcesUpdate(t *testing.T) {
+	t.Parallel()
+
 	// The refspec must carry a leading '+' so that force-pushed (non-fast-forward)
 	// remote branches still update the remote-tracking ref. A missing '+' is the
 	// difference between a successful fetch and a non-fast-forward rejection.
@@ -129,6 +137,8 @@ func TestBranchFetchRefspec_ForcesUpdate(t *testing.T) {
 }
 
 func TestFetch_ForceUpdatedRemoteBranch(t *testing.T) {
+	t.Parallel()
+
 	// Regression: fetching an explicit branch refspec must tolerate a remote
 	// branch that was force-pushed to a divergent history after the local
 	// remote-tracking ref already saw the previous tip. Without the '+' force
@@ -136,7 +146,7 @@ func TestFetch_ForceUpdatedRemoteBranch(t *testing.T) {
 	// exits non-zero as a non-fast-forward update.
 
 	// 1. Setup a "remote" repository
-	remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	remoteScene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
 	require.NoError(t, err)
 	err = remoteScene.Repo.PushBranch("upstream", "main")
@@ -195,11 +205,13 @@ func TestFetch_ForceUpdatedRemoteBranch(t *testing.T) {
 }
 
 func TestResolveExternallyCreatedCommits(t *testing.T) {
+	t.Parallel()
+
 	// The runner resolves commits created outside it (e.g. by a fetch) by
 	// passing through to git; there is no per-process cache to invalidate.
 
 	// 1. Setup a repository
-	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 	// Create a runner and initialize it
 	runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
@@ -233,11 +245,13 @@ func TestResolveExternallyCreatedCommits(t *testing.T) {
 }
 
 func TestPullBranch_FetchResolvesNewCommits(t *testing.T) {
+	t.Parallel()
+
 	// Test that PullBranch works correctly with the refspec fix: a commit fetched
 	// from the remote is resolvable through the long-lived runner afterward.
 
 	// 1. Setup a "remote" repository
-	remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	remoteScene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
 	require.NoError(t, err)
 	err = remoteScene.Repo.PushBranch("upstream", "main")
@@ -291,6 +305,8 @@ func TestPullBranch_FetchResolvesNewCommits(t *testing.T) {
 }
 
 func TestPullBranch_WorktreeCorruptsMainWorkspace(t *testing.T) {
+	t.Parallel()
+
 	// This test reproduces a critical bug where pulling trunk in a worktree
 	// corrupts the main workspace's index/working tree.
 	//
@@ -307,7 +323,7 @@ func TestPullBranch_WorktreeCorruptsMainWorkspace(t *testing.T) {
 	// Root cause: update-ref is global but the index sync is local to the worktree.
 
 	// 1. Setup a "remote" repository with initial content
-	remoteScene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+	remoteScene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 		return s.Repo.CreateChangeAndCommit("initial content", "shared")
 	})
 	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
@@ -409,6 +425,8 @@ func TestPullBranch_WorktreeCorruptsMainWorkspace(t *testing.T) {
 }
 
 func TestPullBranch_WorkingDirSyncWhenOnBranch(t *testing.T) {
+	t.Parallel()
+
 	// This test reproduces a bug where PullBranch leaves the working directory
 	// with uncommitted changes after pulling when we're already on the branch.
 	// The changes appear as the inverse of what was just pulled (reverting the merge).
@@ -417,7 +435,7 @@ func TestPullBranch_WorkingDirSyncWhenOnBranch(t *testing.T) {
 	// we're already on that branch - it doesn't sync the index/working tree.
 
 	// 1. Setup a "remote" repository with initial content
-	remoteScene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+	remoteScene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 		return s.Repo.CreateChangeAndCommit("initial content", "init")
 	})
 	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")

--- a/internal/git/refs_batch_test.go
+++ b/internal/git/refs_batch_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 func TestUpdateRefsBatch(t *testing.T) {
+	t.Parallel()
+
 	t.Run("atomically updates multiple refs", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -54,7 +57,8 @@ func TestUpdateRefsBatch(t *testing.T) {
 	})
 
 	t.Run("fails atomically when OldSHA does not match", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -96,7 +100,8 @@ func TestUpdateRefsBatch(t *testing.T) {
 	})
 
 	t.Run("handles empty updates", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -106,7 +111,8 @@ func TestUpdateRefsBatch(t *testing.T) {
 	})
 
 	t.Run("updates without OldSHA verification", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -128,8 +134,11 @@ func TestUpdateRefsBatch(t *testing.T) {
 }
 
 func TestUpdateRefsBatchWithLog(t *testing.T) {
+	t.Parallel()
+
 	t.Run("updates metadata refs with reflog message", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -151,7 +160,8 @@ func TestUpdateRefsBatchWithLog(t *testing.T) {
 	})
 
 	t.Run("updates branch refs with commits", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -180,8 +190,11 @@ func TestUpdateRefsBatchWithLog(t *testing.T) {
 }
 
 func TestDeleteRefsBatch(t *testing.T) {
+	t.Parallel()
+
 	t.Run("atomically deletes multiple refs", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -213,7 +226,8 @@ func TestDeleteRefsBatch(t *testing.T) {
 	})
 
 	t.Run("handles empty deletion list", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -223,9 +237,10 @@ func TestDeleteRefsBatch(t *testing.T) {
 	})
 
 	t.Run("handles deleting non-existent ref gracefully", func(t *testing.T) {
+		t.Parallel()
 		// Note: git update-ref --stdin with delete does NOT fail on non-existent refs
 		// It silently succeeds, which is different from individual delete operations
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -251,8 +266,11 @@ func TestDeleteRefsBatch(t *testing.T) {
 }
 
 func TestRefUpdateIntegration(t *testing.T) {
+	t.Parallel()
+
 	t.Run("simulates restack atomic update pattern", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()
@@ -300,7 +318,8 @@ func TestRefUpdateIntegration(t *testing.T) {
 	})
 
 	t.Run("simulates undo restore pattern", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 		ctx := context.Background()

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGetRepoInfo(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		url  string
@@ -28,7 +30,8 @@ func TestGetRepoInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+			t.Parallel()
+			scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 			require.NoError(t, scene.Repo.RunGitCommand("config", "remote.origin.url", tt.url))
 
 			got, err := git.NewRunnerWithPath(scene.Dir, nil).GetRepoInfo(context.Background())
@@ -38,7 +41,8 @@ func TestGetRepoInfo(t *testing.T) {
 	}
 
 	t.Run("returns zero value for missing remote", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		got, err := git.NewRunnerWithPath(scene.Dir, nil).GetRepoInfo(context.Background())
 		require.NoError(t, err)
 		require.False(t, got.IsHosted())

--- a/internal/git/staging_test.go
+++ b/internal/git/staging_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 func TestStageAll(t *testing.T) {
+	t.Parallel()
+
 	t.Run("stages all changes including untracked", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		// Create unstaged change
@@ -40,8 +43,11 @@ func TestStageAll(t *testing.T) {
 }
 
 func TestStageTracked(t *testing.T) {
+	t.Parallel()
+
 	t.Run("stages only tracked file changes", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 			// Create initial tracked file
 			return s.Repo.CreateChangeAndCommit("initial", "test")
 		})
@@ -67,8 +73,11 @@ func TestStageTracked(t *testing.T) {
 }
 
 func TestHasStagedChanges(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns false when no staged changes", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		hasStaged, err := runner.HasStagedChanges(context.Background())
@@ -77,7 +86,8 @@ func TestHasStagedChanges(t *testing.T) {
 	})
 
 	t.Run("returns true when changes are staged", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		// Create and stage change
@@ -91,8 +101,11 @@ func TestHasStagedChanges(t *testing.T) {
 }
 
 func TestHasUnstagedChanges(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns false when no unstaged changes", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		hasUnstaged, err := runner.HasUnstagedChanges(context.Background())
@@ -101,7 +114,8 @@ func TestHasUnstagedChanges(t *testing.T) {
 	})
 
 	t.Run("returns true when unstaged changes exist", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 			return s.Repo.CreateChangeAndCommit("initial", "test")
 		})
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
@@ -117,8 +131,11 @@ func TestHasUnstagedChanges(t *testing.T) {
 }
 
 func TestHasUntrackedFiles(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns false when no untracked files", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		hasUntracked, err := runner.HasUntrackedFiles(context.Background())
@@ -127,7 +144,8 @@ func TestHasUntrackedFiles(t *testing.T) {
 	})
 
 	t.Run("returns true when untracked files exist", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		// Create untracked file
@@ -141,8 +159,11 @@ func TestHasUntrackedFiles(t *testing.T) {
 }
 
 func TestAddAll(t *testing.T) {
+	t.Parallel()
+
 	t.Run("is alias for StageAll", func(t *testing.T) {
-		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Dir, nil)
 
 		// Create unstaged change

--- a/internal/git/worktree_ref_test.go
+++ b/internal/git/worktree_ref_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestResolveRefInWorktree(t *testing.T) {
-	scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 		if err := s.Repo.CreateChangeAndCommit("initial", "main"); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- These `internal/git` (and one `internal/engine`) tests used `testhelpers.NewScene`, which `os.Chdir()`s into the scene directory and is explicitly documented (both in the helper itself and in `.claude/rules/testing.md` pitfall #4) as unsafe for parallel tests.
- Verified each touched test never actually depends on the process's working directory — they resolve paths explicitly via `scene.Dir`/`scene.Repo.Dir` (`NewRunnerWithPath`, `NewConfigStore`), or through `testhelpers.GitRepo` methods, which always set `cmd.Dir` on the underlying `exec.Command`.
- Switched those files to `testhelpers.NewSceneParallel` and added `t.Parallel()` at both the top-level test and subtest level, matching the pattern already used elsewhere in the package (e.g. `worktree_test.go`).
- Left untouched: files that call `git.NewRunner(nil)` and therefore do rely on the process cwd (`rebase_test.go`, `diff_test.go`, `remote_test.go`, `remote_metadata_test.go`, `debug_staging_test.go`), files using `t.Setenv` which panics under `t.Parallel()` (`internal/github/pr_info_test.go`), and `worktree_test.go`'s worktree add/remove subtests, which are more sensitive to concurrent execution and already partially converted.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/git/... -race -count=1`
- [x] `go test ./internal/engine/... -race -count=1 -run 'TestApplySplitToCommits|TestContains'`
- [x] `go vet ./internal/git/... ./internal/engine/...`
- [x] `gofmt -l` clean on touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXE8fRfGbpgVd8gTQ5vT4P)_