### PR TITLE
refactor(config): remove dead CombineCICommand/CombineCITimeout shims

### DIFF
--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -890,28 +890,6 @@ func (c *GitConfig) AddSubmitAssignee(assignee string) error {
 	return c.store.Add(KeySubmitAssignees, assignee)
 }
 
-// Deprecated methods for backwards compatibility during migration.
-
-// CombineCICommand returns the CI command (deprecated, use CICommand).
-func (c *GitConfig) CombineCICommand() string {
-	return c.CICommand()
-}
-
-// SetCombineCICommand sets the CI command (deprecated, use SetCICommand).
-func (c *GitConfig) SetCombineCICommand(cmd string) {
-	_ = c.SetCICommand(cmd)
-}
-
-// CombineCITimeout returns the CI timeout (deprecated, use CITimeout).
-func (c *GitConfig) CombineCITimeout() int {
-	return c.CITimeout()
-}
-
-// SetCombineCITimeout sets the CI timeout (deprecated, use SetCITimeout).
-func (c *GitConfig) SetCombineCITimeout(seconds int) {
-	_ = c.SetCITimeout(seconds)
-}
-
 // Save is a no-op for GitConfig since git config writes are immediate.
 // This method exists for API compatibility with the old Config type.
 func (c *GitConfig) Save() error {

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -58,10 +58,6 @@ type Configurer interface {
 	ApprovedHooks(phase string) []string
 	IsHookApproved(phase, command string) bool
 	AddApprovedHook(phase, command string) error
-
-	// Deprecated methods (for backwards compatibility)
-	CombineCICommand() string
-	CombineCITimeout() int
 }
 
 // Ensure GitConfig implements the interface


### PR DESCRIPTION
## Summary
- Removes the four `GitConfig` methods (`CombineCICommand`, `SetCombineCICommand`, `CombineCITimeout`, `SetCombineCITimeout`) and their `Configurer` interface declarations
- These were marked "deprecated ... for backwards compatibility during migration" and have no remaining callers anywhere in the codebase — `CICommand()`/`CITimeout()` are the live replacements
- Does **not** touch the still-used `RepoConfig.CombineCICommand`/`CombineCITimeout` JSON struct fields, which are a separate mechanism consumed by the legacy-config migration in `migrate.go` (verified via `go build ./...`, `go vet ./...`, and `go test ./internal/config/...`, all clean)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/...`
- [x] `gofmt -l` on changed files (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wvo2AtqfgVqv2HuavhxdLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wvo2AtqfgVqv2HuavhxdLw)_