### PR TITLE
fix(get): update the target branch, not the checked-out one

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -314,6 +314,14 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				IsNew:    true,
 			})
 		} else {
+			// Both updates below act on the branch that is currently checked
+			// out: `git reset --hard` moves HEAD's branch, and a merge lands in
+			// HEAD's branch. Without this checkout, running get while trunk is
+			// checked out rewrites trunk to the fetched branch instead of
+			// updating that branch, which silently destroys the local trunk.
+			if err := eng.CheckoutBranch(gctx, branch); err != nil {
+				return fmt.Errorf("failed to check out branch %s: %w", branchName, err)
+			}
 			if opts.Force {
 				if err := eng.ResetHard(gctx, fmt.Sprintf("%s/%s", remote, branchName)); err != nil {
 					return fmt.Errorf("failed to reset branch %s: %w", branchName, err)

--- a/internal/integration/get_test.go
+++ b/internal/integration/get_test.go
@@ -1,7 +1,10 @@
 package integration
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCommand(t *testing.T) {
@@ -66,5 +69,42 @@ func TestGetCommand(t *testing.T) {
 		// Verify local matches remote
 		sh.Run("info").
 			OutputContains("Remote change")
+	})
+
+	// Both update paths act on the checked-out branch: `git reset --hard` moves
+	// HEAD's branch and a merge lands in HEAD's branch. Running get from trunk
+	// used to rewrite trunk to the fetched branch, silently destroying it.
+	t.Run("get does not move trunk when run from trunk", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t, WithRemote())
+
+		sh.Git("checkout -b feature-a").
+			WriteFile("a", "remote content").
+			Git("commit -m 'Remote change'").
+			Git("push -u origin feature-a")
+
+		sh.Run("track feature-a --parent main")
+
+		// Diverge locally so the update path (not the create path) is taken.
+		sh.WriteFile("a", "local content").
+			Git("commit --amend --no-edit")
+
+		// Run get from trunk, which is what triggered the bug.
+		sh.Git("checkout main")
+		sh.Git("rev-parse main")
+		trunkBefore := strings.TrimSpace(sh.Output())
+
+		sh.Run("get feature-a --force --no-restack")
+
+		sh.Git("rev-parse main")
+		require.Equal(t, trunkBefore, strings.TrimSpace(sh.Output()),
+			"get must not move trunk")
+
+		// And the branch it was asked to update actually matches the remote.
+		sh.Git("rev-parse feature-a")
+		branchSHA := strings.TrimSpace(sh.Output())
+		sh.Git("rev-parse origin/feature-a")
+		require.Equal(t, strings.TrimSpace(sh.Output()), branchSHA,
+			"get --force must reset the target branch to the remote")
 	})
 }


### PR DESCRIPTION

Both update paths in get acted on whatever branch HEAD pointed at: `git
reset --hard` moves HEAD's branch, and a merge lands in HEAD's branch.
Neither checked out the branch being updated first, and the only checkout
happened after the loop, for the user's target branch.

Running `stackit get <pr> --force` from trunk therefore reset trunk to each
fetched branch in turn rather than updating those branches, silently
destroying the local trunk. The non-force path has the same defect: it
merges the fetched branch into trunk. Only branches that already exist
locally are affected, since new ones take the CreateBranch path.

Check out the branch before updating it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz
