### PR TITLE
fix(sync): stop reporting a clean dry run when trunk state is unresolvable

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,13 @@ clean. In JSON they appear under `held` as `{branch, reason}` — and also in
 `skipped`, so an empty `conflicts` list alone does not mean the whole stack
 moved.
 
+**`stackit sync --dry-run --json` reports `trunk_state_unknown`.** The preview
+resolves the remote trunk SHA from a listing without fetching its objects, so
+the ancestry check can be unresolvable — in which case trunk is neither reported
+as behind nor proven current. When `trunk_state_unknown` is `true`, an absent
+`would_pull` does **not** mean trunk is up to date; fetch and re-run before
+acting on the preview.
+
 Two smaller shapes changed alongside the worktree work. `stackit tree --json`
 has always omitted worktree anchors from its entries, but `parent` could still
 name one — a dangling reference to a branch absent from the result. Both

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -23,6 +23,7 @@ type DryRunResult struct {
 	WouldRestack       []string `json:"would_restack,omitempty"`        // Branches that would be restacked
 	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering the current dry-run's would_restack set; recompute after sync before passing to `restack --stacks <roots>` because cleanup/reparenting can change roots
 	SkippedStacks      []string `json:"skipped_stacks,omitempty"`       // Stacks skipped due to dirty worktrees
+	TrunkStateUnknown  bool     `json:"trunk_state_unknown,omitempty"`  // Trunk's relationship to its remote could not be resolved (objects not fetched); an absent would_pull does NOT mean trunk is current
 }
 
 // Options contains options for the sync command

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -108,6 +108,7 @@ type dryRunPlan struct {
 	restackStacks []string            // deduped stack roots covering the restack set (JSON only)
 	skipped       []string            // dirty-worktree anchors whose stacks are skipped
 	restacked     bool                // whether --restack was requested
+	trunkUnknown  bool                // trunk's remote relationship could not be resolved
 }
 
 type dryRunCleanItem struct {
@@ -130,6 +131,7 @@ func (p dryRunPlan) toResult() sync.DryRunResult {
 		WouldRestack:       []string{},
 		WouldRestackStacks: p.restackStacks,
 		SkippedStacks:      p.skipped,
+		TrunkStateUnknown:  p.trunkUnknown,
 	}
 	for _, c := range p.clean {
 		result.WouldClean = append(result.WouldClean, c.branch)
@@ -155,7 +157,13 @@ func computeSyncDryRun(ctx context.Context, eng engine.Engine, opts sync.Options
 	// Check if trunk needs to be pulled from remote
 	trunk := eng.Trunk()
 	remoteStatus := eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(trunk)).ForBranch(trunk)
-	if remoteStatus.Behind() {
+	switch {
+	case remoteStatus.Unknown():
+		// Report the uncertainty rather than the absence of work: the remote
+		// SHA is known but its objects are not local, so Behind() is false for
+		// want of a merge base, not because trunk is current.
+		plan.trunkUnknown = true
+	case remoteStatus.Behind():
 		plan.pullBranch = trunk.GetName()
 		plan.pullRev = utils.ShortRevision(remoteStatus.RemoteSha, 0)
 	}
@@ -291,6 +299,12 @@ func renderSyncDryRunText(out output.Output, plan dryRunPlan) {
 		for _, name := range plan.skipped {
 			out.Info("  %s", style.ColorBranchName(name))
 		}
+		printed = true
+	}
+
+	if plan.trunkUnknown {
+		out.Newline()
+		out.Warn("Could not determine whether trunk is behind its remote; fetch and retry.")
 		printed = true
 	}
 

--- a/internal/engine/remote_status_unknown_test.go
+++ b/internal/engine/remote_status_unknown_test.go
@@ -1,0 +1,78 @@
+package engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+)
+
+// A status whose merge base could not be resolved reports false from Behind,
+// Ahead and Diverged alike — the same answers a fully in-sync branch gives.
+// Unknown is what separates "nothing to do" from "could not tell", so callers
+// that act on being up to date have something to branch on.
+func TestBranchRemoteStatusUnknown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  engine.BranchRemoteStatus
+		unknown bool
+	}{
+		{
+			name:    "unresolvable merge base is unknown",
+			status:  engine.BranchRemoteStatus{LocalSha: "aaa", RemoteSha: "bbb", CommonAncestor: ""},
+			unknown: true,
+		},
+		{
+			name:    "matching shas are known and in sync",
+			status:  engine.BranchRemoteStatus{LocalSha: "aaa", RemoteSha: "aaa", CommonAncestor: "aaa"},
+			unknown: false,
+		},
+		{
+			name:    "resolvable merge base is known",
+			status:  engine.BranchRemoteStatus{LocalSha: "aaa", RemoteSha: "bbb", CommonAncestor: "aaa"},
+			unknown: false,
+		},
+		{
+			name:    "no remote ref is not unknown, it is absent",
+			status:  engine.BranchRemoteStatus{LocalSha: "aaa", RemoteSha: "", CommonAncestor: ""},
+			unknown: false,
+		},
+		{
+			name:    "no local ref is not unknown, it is absent",
+			status:  engine.BranchRemoteStatus{LocalSha: "", RemoteSha: "bbb", CommonAncestor: ""},
+			unknown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.unknown, tt.status.Unknown())
+		})
+	}
+}
+
+// The ambiguity this guards against. An unresolvable status answers every other
+// predicate with a definite-looking value derived from missing data: Behind and
+// Ahead are false (so a caller checking only Behind concludes there is nothing
+// to pull), while Diverged is true purely because an empty common ancestor
+// equals neither sha. Unknown is the only honest signal.
+func TestBranchRemoteStatusUnknownIsIndistinguishableWithoutUnknown(t *testing.T) {
+	t.Parallel()
+
+	status := engine.BranchRemoteStatus{LocalSha: "aaa", RemoteSha: "bbb", CommonAncestor: ""}
+
+	require.True(t, status.Unknown())
+
+	// Reads as "nothing to pull", which is what made sync --dry-run report a
+	// clean preview while trunk was behind.
+	require.False(t, status.Behind())
+	require.False(t, status.Ahead())
+	require.False(t, status.Matches())
+
+	// And reads as a definite divergence, which is equally unfounded.
+	require.True(t, status.Diverged())
+}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -261,6 +261,21 @@ func (s BranchRemoteStatus) Behind() bool {
 	return s.CommonAncestor == s.LocalSha
 }
 
+// Unknown reports that the local/remote relationship could not be determined:
+// both sides exist and differ, but no merge base was resolvable. That happens
+// when the remote object is not in the local object database — the remote SHA
+// came from a listing (ls-remote) and nothing has fetched the objects yet.
+//
+// Behind, Ahead and Diverged all return false in that state, which is
+// indistinguishable from "in sync". Callers that act on being up to date must
+// check this first rather than treating a silent false as a clean bill.
+func (s BranchRemoteStatus) Unknown() bool {
+	if s.Matches() || s.LocalSha == "" || s.RemoteSha == "" {
+		return false
+	}
+	return s.CommonAncestor == ""
+}
+
 // Diverged returns true if both local and remote have unique commits
 func (s BranchRemoteStatus) Diverged() bool {
 	if s.Matches() || s.LocalSha == "" || s.RemoteSha == "" {


### PR DESCRIPTION

The dry-run preview resolves remote SHAs from a listing (ls-remote) without
fetching objects, so `git merge-base` can fail for want of the remote commit.
That error was swallowed, leaving CommonAncestor empty, and Behind() reads an
empty ancestor as "not behind" — so the preview reported "Everything is up to
date" while trunk was well behind its remote. Diverged() reads the same empty
ancestor as a definite divergence, so neither answer was trustworthy.

Add BranchRemoteStatus.Unknown(), derived from the existing fields with no
behavior change to the other predicates, and have the trunk preview report the
uncertainty instead of the absence of work. Surfaced in --json as
trunk_state_unknown so scripts do not read a missing would_pull as current.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz
