### PR TITLE
fix(get): record the PR details it already fetched

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -105,6 +105,9 @@ type syncTargets struct {
 	branches       []string
 	parentByBranch map[string]string
 	prByBranch     map[string]*int
+	// Full PR records for branches resolved through GitHub, so the details
+	// already paid for are recorded rather than reduced to a number.
+	prInfoByBranch map[string]*engine.PrInfo
 }
 
 func newSyncTargets(targetBranch string) *syncTargets {
@@ -112,6 +115,7 @@ func newSyncTargets(targetBranch string) *syncTargets {
 		branches:       []string{targetBranch},
 		parentByBranch: make(map[string]string),
 		prByBranch:     make(map[string]*int),
+		prInfoByBranch: make(map[string]*engine.PrInfo),
 	}
 }
 
@@ -195,6 +199,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	branchesToSync := targets.branches
 	parentMap := targets.parentByBranch
 	branchPRInfo := targets.prByBranch
+	// Full PR records for every branch whose PR we resolved, persisted after the
+	// sync loop so the branches carry GitHub state immediately.
+	fetchedPRs := targets.prInfoByBranch
 
 	// If target branch exists locally, identify local descendants
 	targetBranchObj := eng.GetBranch(targetBranch)
@@ -271,8 +278,14 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		utils.Run(branchesToFetch, func(branchName string) {
 			if pr, err := ctx.GitHub().GetPullRequestByBranch(remoteCtx, branchName); err == nil && pr != nil {
 				prNum := pr.Number
+				// Keep the whole record, not just the number: get already paid
+				// for this round trip, and without it the branch lands with no
+				// PR metadata at all, so `tree full` renders no GitHub state
+				// until the next sync repeats the same fetch.
+				info := engine.NewPrInfo(&prNum, pr.Title, pr.Body, pr.State, pr.Base, pr.HTMLURL, pr.Draft)
 				mu.Lock()
 				branchPRInfo[branchName] = &prNum
+				fetchedPRs[branchName] = info
 				mu.Unlock()
 			}
 		})
@@ -347,6 +360,15 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	if freezeSet := branchesToFreeze.Build(); len(freezeSet) > 0 {
 		if _, err := eng.SetFrozen(ctx, freezeSet, true); err != nil {
 			out.Debug("Failed to freeze new branches: %v", err)
+		}
+	}
+
+	// Record the PR details fetched above. Without this the branch has no PR
+	// metadata locally, and every consumer that filters on it — `tree full`
+	// most visibly — shows nothing until a later sync refetches the same data.
+	if len(fetchedPRs) > 0 {
+		if err := eng.BatchUpsertPrInfo(gctx, fetchedPRs); err != nil {
+			out.Debug("Failed to record PR info: %v", err)
 		}
 	}
 
@@ -525,6 +547,7 @@ func (targets *syncTargets) crawlAncestorsViaGitHub(ctx context.Context, gh gith
 		}
 		prNum := pr.Number
 		targets.prByBranch[current] = &prNum
+		targets.prInfoByBranch[current] = engine.NewPrInfo(&prNum, pr.Title, pr.Body, pr.State, pr.Base, pr.HTMLURL, pr.Draft)
 
 		base := pr.Base
 		if base == "" || base == eng.Trunk().GetName() {

--- a/internal/integration/get_metadata_test.go
+++ b/internal/integration/get_metadata_test.go
@@ -146,6 +146,42 @@ func TestGetMetadataDiscovery(t *testing.T) {
 			"get should fall back to the GitHub crawl when metadata is absent")
 	})
 
+	// get pays for a GetPullRequestByBranch round trip whenever metadata cannot
+	// supply the PR. Discarding everything but the number left the branch with no
+	// PR metadata at all, so `tree full` — which only renders GitHub state for
+	// branches that have a recorded PR — showed nothing until a later sync
+	// refetched the very same data.
+	t.Run("records the PR it fetched so the branch carries GitHub state", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewRemoteScenario(t)
+
+		sh.CreateBranchQuiet("feature-y")
+		sh.CommitChange("fy.txt", "feature y")
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "-u", "origin", "feature-y"))
+		sh.CheckoutQuiet("main")
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "feature-y"))
+		sh.Rebuild()
+
+		config := testhelpers.NewMockGitHubServerConfig()
+		config.PRs["feature-y"] = &github.PullRequest{
+			Number: new(77),
+			Title:  new("Add feature y"),
+			Head:   &github.PullRequestBranch{Ref: new("feature-y")},
+			Base:   &github.PullRequestBranch{Ref: new("main")},
+			State:  new("open"),
+		}
+		sh.Context.GitHubClient = newCountingGitHubClient(t, config)
+
+		require.NoError(t, actions.GetAction(sh.Context, "feature-y", actions.GetOptions{Restack: true}, &actions.GetNullHandler{}))
+		sh.Rebuild()
+
+		prInfo, err := sh.Engine.GetPrInfo(sh.Engine.GetBranch("feature-y"))
+		require.NoError(t, err)
+		require.NotNil(t, prInfo, "get should record the PR it fetched")
+		require.NotNil(t, prInfo.Number())
+		require.Equal(t, 77, *prInfo.Number())
+	})
+
 	t.Run("falls back to GitHub when ancestor metadata is missing", func(t *testing.T) {
 		t.Parallel()
 		sh := scenario.NewRemoteScenario(t)


### PR DESCRIPTION

get resolves a branch's pull request either from remote metadata or by asking
GitHub, then kept only the number for display and discarded the rest. Nothing
persisted it, so a branch pulled down with get carried no PR metadata at all.

`tree full` renders GitHub state only for branches with a recorded PR, so it
showed an empty tree straight after a get — despite get having just fetched
exactly that data — until a later sync repeated the same round trips.

Carry the full record through both resolution paths and upsert it once the
branches exist.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz
