### PR TITLE
fix(build): do not fail the build when web assets are absent

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -18,6 +18,13 @@ The stackit web app is a dashboard for visualizing stacked branches. It displays
 
 The web app is built as a **static export** (no server-side rendering). The built output (`apps/web/out/`) is copied into `apps/server/static/` and embedded in the Go binary via `//go:embed static`. The API server serves these static files alongside the `/api/` endpoints, creating a single self-contained binary.
 
+The copy step is `scripts/sync-web-static.sh` (`mise run web:sync-static`). The
+web output is gitignored, so a fresh clone has none — rather than fail the build
+and leave `mise run build` half-finished, the script embeds a placeholder page
+explaining that the UI was not built and exits successfully. The API is
+unaffected; run `mise run web:build` then `mise run web:sync-static` for the
+real UI.
+
 ```
 Browser → Go API server → /api/* (JSON endpoints)
                         → /*    (embedded static files)

--- a/scripts/sync-web-static.sh
+++ b/scripts/sync-web-static.sh
@@ -4,11 +4,31 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-if [ ! -f apps/web/out/index.html ]; then
-  echo "apps/web/out/index.html is missing; run 'pnpm --filter @stackit/web build' first." >&2
-  exit 1
-fi
-
 mkdir -p apps/server/static
 find apps/server/static -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf {} +
+
+# The web build output is gitignored, so a fresh clone has none. Failing here
+# would break `mise run build` — which builds the CLI first — leaving a usable
+# bin/stackit behind a non-zero exit. Emit a placeholder instead so the server
+# still compiles (//go:embed needs the directory populated) and says plainly
+# why the UI is missing.
+if [ ! -f apps/web/out/index.html ]; then
+  echo "apps/web/out/index.html is missing; embedding a placeholder page." >&2
+  echo "Run 'mise run web:build' (or 'pnpm --filter @stackit/web build') for the real UI." >&2
+  cat > apps/server/static/index.html <<'HTML'
+<!doctype html>
+<meta charset="utf-8">
+<title>stackit — web UI not built</title>
+<body style="font: 14px system-ui; margin: 3rem auto; max-width: 34rem">
+  <h1>Web UI not built</h1>
+  <p>This server was built without the web assets, so a placeholder is embedded
+     in their place. The API is unaffected.</p>
+  <p>To build the real UI:</p>
+  <pre>mise run web:build
+mise run web:sync-static</pre>
+</body>
+HTML
+  exit 0
+fi
+
 cp -R apps/web/out/. apps/server/static/


### PR DESCRIPTION

The web export is gitignored, so a fresh clone has none and
scripts/sync-web-static.sh exited 1. `mise run build` builds the CLI before
calling it, so the result was a partial success: bin/stackit written, no
stackit-server, and a non-zero exit that reads as a total failure. Every clean
checkout, CI job, and agent hit it.

Embed a placeholder page instead, so //go:embed has something to include, the
server still compiles, and the page says plainly that the UI was not built and
how to build it. The API is unaffected.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz
