### PR TITLE
fix(submit): retarget a base past a Stack pinned open by a merged PR

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -667,8 +667,21 @@ func dissolveGitHubStack(ctx *app.Context, pullRequest int) error {
 	if err != nil {
 		return err
 	}
-	if !dissolved {
-		return fmt.Errorf("GitHub Stack #%d still holds pull requests that are merged or queued to merge", stack.Number)
+	if dissolved {
+		return nil
+	}
+
+	// GitHub refuses to unstack merged or queued pull requests, so a stack that
+	// outlived one of its members never dissolves outright — and after any
+	// member merges, that is the normal state. What actually gates the base
+	// change is whether *this* pull request is still stacked, not whether the
+	// stack is empty: the leftovers belong to PRs that have already landed.
+	remaining, err := stackClient.FindStackByPullRequest(remoteCtx, pullRequest)
+	if err != nil {
+		return err
+	}
+	if remaining != nil {
+		return fmt.Errorf("GitHub Stack #%d still holds pull request %d, which is merged or queued to merge", remaining.Number, pullRequest)
 	}
 	return nil
 }
@@ -971,6 +984,13 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		// retarget the PR, and the stack cannot be repaired from the GitHub UI.
 		if dissolveErr := dissolveGitHubStack(ctx, *submissionInfo.PRNumber); dissolveErr != nil {
 			ctx.Output.Debug("Failed to dissolve native GitHub Stack for %s: %v", submissionInfo.BranchName, dissolveErr)
+			// The GitHub error that follows only says the base cannot change
+			// while the PR is in a Stack. Say that the recovery was attempted
+			// and why it did not work, or the failure looks unexplained.
+			handler.OnEvent(BranchWarningEvent{
+				BranchName: submissionInfo.BranchName,
+				Warning:    fmt.Sprintf("could not dissolve the native GitHub Stack to retarget the base: %v", dissolveErr),
+			})
 		} else {
 			handler.OnEvent(BranchWarningEvent{
 				BranchName: submissionInfo.BranchName,

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -1117,3 +1117,46 @@ func TestSubmitDissolvesNativeGitHubStackToRetargetBase(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "main", apiPR.Base())
 }
+
+// TestSubmitRetargetsBaseWhenStackKeepsMergedPullRequest covers the state a
+// stack lands in as soon as one of its members merges: GitHub refuses to
+// unstack a merged pull request, so the Stack never dissolves outright. Treating
+// that as a failed dissolve left the base retarget blocked and surfaced GitHub's
+// raw 422, even though the pull request being retargeted had in fact left the
+// Stack — and a later submit would then succeed, making it look intermittent.
+func TestSubmitRetargetsBaseWhenStackKeepsMergedPullRequest(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"base": "main", "api": "base"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	mockConfig := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, mockConfig)
+	s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, mockConfig)
+
+	cfg, err := stackitconfig.LoadConfig(s.Scene.Dir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetStackShape(stackitconfig.StackShapeLinear))
+	s.Context.Config = cfg
+
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true, CreateGitHubStack: true}, &noopHandler{})
+	require.NoError(t, err)
+	require.Len(t, mockConfig.CreatedStacks, 1)
+	require.NotEmpty(t, mockConfig.CreatedStacks[0])
+
+	// The bottom pull request merges. GitHub keeps it in the Stack and will not
+	// unstack it, so the Stack can never be emptied from here on.
+	mockConfig.MergedStackPRs = []int{mockConfig.CreatedStacks[0][0]}
+
+	s.TrackBranch("api", "main").Checkout("api")
+	err = submit.Action(s.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{})
+	require.NoError(t, err, "a Stack pinned open by a merged PR must not block retargeting the others")
+
+	apiPR, err := s.Engine.GetBranch("api").GetPrInfo()
+	require.NoError(t, err)
+	require.Equal(t, "main", apiPR.Base())
+
+	require.Equal(t, mockConfig.MergedStackPRs, mockConfig.CreatedStacks[0],
+		"only the merged pull request should remain stacked")
+}


### PR DESCRIPTION

GitHub refuses to unstack a merged or queued pull request, so once any member
of a native Stack lands, that Stack can never be dissolved outright. The
recovery for a 422 base conflict treated anything short of an empty Stack as a
failed dissolve, gave up, and surfaced GitHub's raw error:

  Cannot change the base branch because the pull request is part of a stack.

The unstack had in fact removed the pull request being retargeted; only the
merged one stayed behind. So the next submit succeeded, which made the failure
look intermittent rather than tied to a member merging.

Gate the retry on whether this pull request is still stacked rather than on the
Stack being empty, and report a failed dissolve as a warning — the GitHub error
alone gives no hint that a recovery was attempted.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGCXmdQuQwZvpDWzUvo1Jz
