### PR TITLE
fix(git): stop truncating multi-line stackit config values

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -92,7 +92,12 @@ func (c *ConfigStore) stackitSnapshot() (map[string]string, error) {
 		return c.stackitKeys, nil
 	}
 
-	out, err := c.runGitConfig("--get-regexp", `^stackit\.`)
+	// -z is what makes this parseable: it frames each entry as
+	// "key\nvalue\0", so a value containing a newline (a multi-line
+	// stackit.ci.command, say) stays one record. Without it git separates
+	// entries by newline too, and a multi-line value is indistinguishable
+	// from the start of the next key.
+	out, err := c.runGitConfig("-z", "--get-regexp", `^stackit\.`)
 	// Exit code 1 means no stackit.* key is set at all — an empty snapshot,
 	// not a failure.
 	if err != nil && !isExitCode(err, 1) {
@@ -100,12 +105,14 @@ func (c *ConfigStore) stackitSnapshot() (map[string]string, error) {
 	}
 
 	keys := make(map[string]string)
-	for _, line := range strings.Split(out, "\n") {
-		name, value, found := strings.Cut(line, " ")
-		if !found || name == "" {
+	for _, record := range strings.Split(out, "\x00") {
+		if record == "" {
 			continue
 		}
-		// Later lines win, matching `git config --get` precedence
+		// A valueless key ("[stackit]\n\tfoo") has no newline at all; it
+		// reads as an empty value, which is what Get returned for it before.
+		name, value, _ := strings.Cut(record, "\n")
+		// Later records win, matching `git config --get` precedence
 		// (system, then global, then local).
 		keys[name] = value
 	}

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -53,6 +53,24 @@ func TestConfigStore_GetSet(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "second", val)
 	})
+
+	t.Run("round-trips a value containing newlines", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+		store := git.NewConfigStore(scene.Dir)
+
+		// stackit.ci.command is free-form user text and gates merge CI
+		// validation, so a multi-line value silently truncated to its first
+		// line would run half the command and report a clean gate.
+		multiline := "make lint\nmake test"
+		err := store.Set("stackit.ci.command", multiline)
+		require.NoError(t, err)
+
+		val, err := store.Get("stackit.ci.command")
+		require.NoError(t, err)
+		require.Equal(t, multiline, val)
+	})
 }
 
 func TestConfigStore_Bool(t *testing.T) {


### PR DESCRIPTION

The batched stackit.* snapshot read the keys with `git config
--get-regexp` and split the output on newlines, so a value containing a
newline was cut at its first line and its remainder was parsed as a
separate bogus key. stackit.ci.command is free-form user text that gates
merge CI validation, so a two-line command ran only its first line and
reported a clean gate.

Read the snapshot with -z instead, which frames each entry as
"key\nvalue\0" and is unambiguous for values containing newlines.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1720** 👈
  * **PR #1721**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->