### PR TITLE
ci(release): assert the web export exists before building

### DIFF
--- a/.goreleaser.docker.yml
+++ b/.goreleaser.docker.yml
@@ -17,6 +17,12 @@ before:
     - go mod tidy
     - pnpm install --frozen-lockfile
     - pnpm --filter @stackit/web build
+    # sync-web-static.sh deliberately falls back to a placeholder page when the
+    # web export is missing, so `mise run build` works on a fresh clone. A
+    # release must not ship that placeholder, so assert the real export exists
+    # before it runs. `pnpm --filter` exits 0 on a no-match, so a renamed
+    # package or workspace glob would otherwise sail through both hooks.
+    - test -f apps/web/out/index.html
     - ./scripts/sync-web-static.sh
 
 builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,12 @@ before:
     - go mod tidy
     - pnpm install --frozen-lockfile
     - pnpm --filter @stackit/web build
+    # sync-web-static.sh deliberately falls back to a placeholder page when the
+    # web export is missing, so `mise run build` works on a fresh clone. A
+    # release must not ship that placeholder, so assert the real export exists
+    # before it runs. `pnpm --filter` exits 0 on a no-match, so a renamed
+    # package or workspace glob would otherwise sail through both hooks.
+    - test -f apps/web/out/index.html
     - ./scripts/sync-web-static.sh
 
 builds:


### PR DESCRIPTION

sync-web-static.sh embeds a placeholder page when apps/web/out is
missing, so `mise run build` works on a fresh clone. That fallback is
right for local builds and wrong for a release: it is now the only thing
standing between a web build that exits 0 without emitting output and a
published stackit-server whose embedded UI is the placeholder.

`pnpm --filter` exits 0 on a no-match, so a renamed package or a drifted
workspace glob would pass both existing hooks silently. Assert the
artifact itself instead of trusting the build hook, in the release config
and in the Docker one that feeds the ghcr.io :main image.