### PR TITLE
refactor(style): use named options instead of positional bools for branch coloring

### DIFF
--- a/internal/cli/info_render.go
+++ b/internal/cli/info_render.go
@@ -56,7 +56,7 @@ type branchInfoRenderOptions struct {
 func renderBranchInfoText(info actions.BranchInfoResult, opts branchInfoRenderOptions) string {
 	var outputLines []string
 
-	coloredBranchName := style.ColorBranchNameWithTrunk(info.Name, info.IsCurrent, info.IsTrunk)
+	coloredBranchName := style.ColorBranchNameWithTrunk(info.Name, style.BranchStyleOpts{IsCurrent: info.IsCurrent, IsTrunk: info.IsTrunk})
 	if info.IsLocked {
 		coloredBranchName += " " + style.IconLocked() + " " + style.ColorDim("(locked)")
 	}
@@ -92,13 +92,13 @@ func renderBranchInfoText(info actions.BranchInfoResult, opts branchInfoRenderOp
 
 	if info.Parent != "" {
 		outputLines = append(outputLines, "")
-		outputLines = append(outputLines, fmt.Sprintf("%s: %s", style.ColorCyan("Parent"), style.ColorBranchNameWithTrunk(info.Parent, false, isTrunkName(info.Parent))))
+		outputLines = append(outputLines, fmt.Sprintf("%s: %s", style.ColorCyan("Parent"), style.ColorBranchNameWithTrunk(info.Parent, style.BranchStyleOpts{IsTrunk: isTrunkName(info.Parent)})))
 	}
 
 	if len(info.Children) > 0 {
 		outputLines = append(outputLines, fmt.Sprintf("%s:", style.ColorCyan("Children")))
 		for _, child := range info.Children {
-			outputLines = append(outputLines, fmt.Sprintf("▸ %s", style.ColorBranchNameWithTrunk(child, false, isTrunkName(child))))
+			outputLines = append(outputLines, fmt.Sprintf("▸ %s", style.ColorBranchNameWithTrunk(child, style.BranchStyleOpts{IsTrunk: isTrunkName(child)})))
 		}
 	}
 

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -128,7 +128,7 @@ func (p *planPrinter) Flush() {
 
 	header := style.ColorMagenta("Submit plan")
 	if p.trunk != "" {
-		header += " → " + style.ColorBranchNameWithTrunk(p.trunk, false, true)
+		header += " → " + style.ColorBranchNameWithTrunk(p.trunk, style.BranchStyleOpts{IsTrunk: true})
 	}
 	p.out.Info("%s", header)
 
@@ -216,8 +216,8 @@ func (p *planPrinter) printSoloLine(ev submit.BranchPlanEvent) {
 
 	if ev.Skipped {
 		p.out.Info("%s → %s %s",
-			style.ColorBranchNamePlain(name, ev.IsCurrent, false),
-			style.ColorBranchNameWithTrunk(base, false, base == p.trunk),
+			style.ColorBranchNamePlain(name, style.BranchStyleOpts{IsCurrent: ev.IsCurrent}),
+			style.ColorBranchNameWithTrunk(base, style.BranchStyleOpts{IsTrunk: base == p.trunk}),
 			style.ColorDim("— "+ev.SkipReason))
 		return
 	}
@@ -226,7 +226,7 @@ func (p *planPrinter) printSoloLine(ev submit.BranchPlanEvent) {
 	if ev.PRNumber != nil {
 		action = fmt.Sprintf("%s %s", action, style.ColorYellow(fmt.Sprintf("#%d", *ev.PRNumber)))
 	}
-	line := fmt.Sprintf("%s → %s  %s", style.ColorBranchNamePlain(name, ev.IsCurrent, false), style.ColorBranchNameWithTrunk(base, false, base == p.trunk), colorAction(ev.Action, action))
+	line := fmt.Sprintf("%s → %s  %s", style.ColorBranchNamePlain(name, style.BranchStyleOpts{IsCurrent: ev.IsCurrent}), style.ColorBranchNameWithTrunk(base, style.BranchStyleOpts{IsTrunk: base == p.trunk}), colorAction(ev.Action, action))
 	if ev.Empty {
 		line += " " + style.ColorDim("(empty)")
 	}
@@ -254,7 +254,7 @@ func (p *planPrinter) pad(name string, dim bool, current bool) string {
 	if dim {
 		return style.ColorDim(padded)
 	}
-	return style.ColorBranchNamePlain(padded, current, false)
+	return style.ColorBranchNamePlain(padded, style.BranchStyleOpts{IsCurrent: current})
 }
 
 // skippedCount is the number of plan rows that were skipped.

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -25,12 +25,12 @@ func Branch(name string, isCurrent bool) string {
 
 // BranchNameWithTrunk renders a non-current branch name, with trunk in a distinct color.
 func BranchNameWithTrunk(name string, isTrunk bool) string {
-	return style.ColorBranchNameWithTrunk(name, false, isTrunk)
+	return style.ColorBranchNameWithTrunk(name, style.BranchStyleOpts{IsTrunk: isTrunk})
 }
 
 // BranchWithTrunk is like Branch but renders the trunk branch in a distinct color.
 func BranchWithTrunk(name string, isCurrent, isTrunk bool) string {
-	return style.ColorBranchNameWithTrunk(name, isCurrent, isTrunk)
+	return style.ColorBranchNameWithTrunk(name, style.BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: isTrunk})
 }
 
 // Dim renders text in a dim/gray style.

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -972,7 +972,7 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 	// TRUNK: minimal single line
 	if isTrunk {
 		branchName := args.branchName
-		coloredBranchName := style.ColorBranchNamePlain(branchName, isCurrent, true)
+		coloredBranchName := style.ColorBranchNamePlain(branchName, style.BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: true})
 		if isSelected {
 			coloredBranchName = style.Selection().Render(" " + branchName + " ")
 		} else if !matchesSearch && args.searchQuery != "" {
@@ -1001,7 +1001,7 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 
 	// LINE 1: Symbol + Branch Name (bold if current) + SHA + Scope + Actionable Warnings
 	branchName := args.branchName
-	coloredBranchName := style.ColorBranchNamePlain(branchName, isCurrent, isTrunk)
+	coloredBranchName := style.ColorBranchNamePlain(branchName, style.BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: isTrunk})
 
 	switch {
 	case isSelected && !isNonSelectable:
@@ -1438,7 +1438,7 @@ func (r *StackTreeRenderer) RenderBranchList(branches []string) []string {
 			line += BranchSymbol + " "
 		}
 
-		line += style.ColorBranchNameWithTrunk(branchName, isCurrent, r.isTrunk(branchName))
+		line += style.ColorBranchNameWithTrunk(branchName, style.BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: r.isTrunk(branchName)})
 		line += r.FormatAnnotationColored(annotation)
 
 		result = append(result, line)

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -798,7 +798,7 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 		}
 
 		// Get colored branch name
-		coloredBranchName := style.ColorBranchNameWithTrunk(branch.GetName(), isCurrent, branch.IsTrunk())
+		coloredBranchName := style.ColorBranchNameWithTrunk(branch.GetName(), style.BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: branch.IsTrunk()})
 
 		// Add annotation
 		annotation := annotations[branch.GetName()]

--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -94,19 +94,19 @@ func ColorBranchNameIf(branchName string, isCurrent bool) string {
 }
 
 // ColorBranchNameWithTrunk colors a branch name based on whether it's current and trunk status
-func ColorBranchNameWithTrunk(branchName string, isCurrent bool, isTrunk bool) string {
+func ColorBranchNameWithTrunk(branchName string, opts BranchStyleOpts) string {
 	name := branchName
-	if isCurrent {
+	if opts.IsCurrent {
 		name += " (current)"
 	}
-	return BranchStyle(BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: isTrunk}).Render(name)
+	return BranchStyle(opts).Render(name)
 }
 
 // ColorBranchNamePlain colors a branch name by current/trunk status without
 // appending the " (current)" marker, for callers that already convey
 // currency another way (e.g. a leading cursor or row highlight).
-func ColorBranchNamePlain(branchName string, isCurrent, isTrunk bool) string {
-	return BranchStyle(BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: isTrunk}).Render(branchName)
+func ColorBranchNamePlain(branchName string, opts BranchStyleOpts) string {
+	return BranchStyle(opts).Render(branchName)
 }
 
 // BranchStyleOpts configures the appearance BranchStyle renders.


### PR DESCRIPTION
## Summary

- `ColorBranchNameWithTrunk` and `ColorBranchNamePlain` (in `internal/tui/style/formatter.go`) took two adjacent positional `bool` parameters, so call sites like `ColorBranchNameWithTrunk(name, false, true)` were unreadable without checking the function signature — exactly the anti-pattern called out in `.claude/rules/code-style.md`'s "Boolean Parameters" section.
- Both functions already constructed a `BranchStyleOpts` struct internally, so they now take that struct directly as their second parameter instead of two bools.
- Updated every call site (12 across `internal/cli`, `internal/cli/stack`, `internal/output`, `internal/tui`, and `internal/tui/components/tree`) to pass named `style.BranchStyleOpts{...}` fields instead of bare/positional booleans.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/...`
- [x] `go test ./internal/cli/... ./internal/cli/stack/... ./internal/tui/... ./internal/output/...` — all pass
- [x] `gofmt -l` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiCb6VMVkRvDdQKNeu5RBy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiCb6VMVkRvDdQKNeu5RBy)_