### PR TITLE
fix(get): survive a landed parent that left the remote

### DIFF
--- a/.claude/rules/multiplayer-safety.md
+++ b/.claude/rules/multiplayer-safety.md
@@ -90,6 +90,23 @@ commits — never the landed parent's pre-merge commits.**
 - Never delete or reparent branch metadata based solely on SHA equality. Deletion
   stays gated on submitted-PR metadata (`metaHasSubmittedPR`); reparenting is the
   non-destructive path and does not require that gate.
+- This holds for `get` too, before any local history exists. A landed parent that
+  GitHub deleted must not fail the fetch (explicit refspecs are all-or-nothing:
+  drop the gone branches and fetch the rest), and the child tracked against a
+  substitute parent must carry the landed parent's recorded tip as its
+  divergence anchor — a plain merge-base against trunk replays the landed
+  commits for squash and rebase merges. See `TrackBranchPastLandedParent`.
+- `get` checks branches out frozen, and restack never rebases a frozen branch. A
+  re-anchored branch is therefore still stale: report it and offer the unfreeze,
+  never re-anchor silently.
+- The anchor must be recovered from **any** metadata that survives, not only from
+  a clean ancestry crawl. Branch cleanup deletes a merged branch's remote metadata
+  ref, so the crawl routinely falls back to a GitHub walk that reads PR bases and
+  knows no revisions; the child's own metadata ref still records the tip it was
+  pushed on top of. See `harvestAnchors`.
+- With **no** anchor available, re-anchor but never offer to rebase. Report the
+  branch as unanchored and leave it frozen: a rebase there replays the landed
+  commits instead of dropping them, which is the data-loss shape itself.
 
 ## Performance: Keep The Squash Scan Cold
 
@@ -111,5 +128,13 @@ Any change to detection, reparenting, or the guard must cover:
 - **A multi-commit squash** case specifically.
 - **Guard boundaries**: ahead/diverged rejected; equal/behind/no-remote/no-branches
   allowed.
+- **Trunk that moved on after the merge.** A landed parent whose commits are
+  replayed onto an unchanged trunk applies as a no-op and `git rebase` drops it,
+  so the test passes for the wrong reason. Advance trunk past the merge before
+  asserting.
+- **Every degree of surviving metadata**, for anything touching `get`: all refs
+  intact, the landed parent's metadata ref already cleaned up (the common case
+  after the author syncs), and no stackit metadata at all. The middle case is the
+  one a single "happy path" test misses.
 
 See `docs/multiplayer.md` for the test-file map.

--- a/README.md
+++ b/README.md
@@ -434,6 +434,10 @@ stackit get 123
 ```
 By default, `get` **freezes** the fetched branches locally. This prevents accidental local modifications while you build on top of them, without affecting the original author's metadata. Use `stackit unfreeze` if you need to modify them.
 
+If part of the stack has already merged and GitHub deleted those branches, `get` tracks what is left against the nearest branch that still exists — usually trunk — and says which landed branch it moved past. The fetched branch still contains the landed commits until it is rebased, and a frozen branch is never rebased, so `get` offers to unfreeze and restack it there and then. Declining is fine: the branch keeps mirroring the remote, and `stackit unfreeze` followed by `stackit restack` finishes the job whenever you are ready.
+
+Occasionally there is nothing on the remote recording which commit the branch was pushed on top of — a branch pushed without stackit whose parent has since merged. `get` still re-anchors it, but it says the landed commits can't be told apart from the branch's own and leaves it frozen, because rebasing it would duplicate the merged work rather than drop it.
+
 ### Native GitHub Stack Sync (Experimental)
 
 GitHub's native stacked PR UI requires a linear PR chain. To reconcile its server-side Stack metadata automatically during normal submission, enable the option once:

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -102,6 +102,91 @@ Stackit must also never move an unrelated branch ref to a merged **sibling's**
 stale pre-merge tip, and must never delete or reparent metadata based solely on
 SHA equality.
 
+## Fetching a branch whose parent has landed
+
+`stackit get` faces the same landed work one step earlier: it fetches a branch
+from the remote before there is any local history to reason about. The child's
+pushed metadata still names the parent it was submitted against, and GitHub has
+already deleted that branch as part of the merge.
+
+Two things go wrong without care.
+
+**The fetch is all-or-nothing.** `get` resolves the target's ancestry from the
+fetched metadata and then asks for every ancestor head in one refspec list.
+`git fetch` fails the whole command when a single explicit refspec names a ref
+that no longer exists, so the branch the user actually asked for never arrives:
+
+```
+Error: failed to fetch branches from origin: git fetch failed:
+fatal: couldn't find remote ref refs/heads/<merged-parent>
+```
+
+`get` recovers by listing the remote's refs (`MissingRemoteBranches`), dropping
+the branches that are gone, and fetching the rest. That listing runs **only on
+the failure path**, so a healthy stack still fetches in one round trip.
+
+**The substitute parent needs the right divergence point.** A branch discovered
+through metadata that has no ref on the remote was pushed once and has landed,
+so `get` drops it from the sync set and tracks its children against the nearest
+ancestor that still exists — usually trunk. Recording that parent alone is not
+enough: the fetched branch still contains the landed parent's commits, and a
+plain merge-base against trunk puts them all back into a later restack's replay
+range for every merge method that rewrites SHAs.
+
+`TrackBranchPastLandedParent` records the parent the branch was actually pushed
+on top of, plus that parent's tip from the same metadata, before setting the new
+parent. The tip is still reachable from the fetched branch even though its ref
+is gone, so `SetParent`'s recompute path can check whether it landed and keep it
+as the divergence anchor. The reparent invariant above then holds through `get`
+as well: `<trunk>..<branch>` is exactly the branch's own commits.
+
+A parent that is gone from the remote but **still checked out locally** is left
+alone. It is a branch the user may still be working with, and restack's own
+landed-parent handling reparents past it.
+
+### Where the anchor comes from, and what happens without one
+
+The anchor is a branch's own recorded `ParentBranchRevision`, so it survives the
+landed parent's metadata being deleted — but only if `get` goes looking for it.
+
+`crawlAncestorsViaMetadata` collects anchors as it walks, and abandons the whole
+walk the moment one ancestor has no metadata. That is exactly the state a merged
+parent is left in: branch cleanup deletes a merged branch's remote metadata ref
+during the author's own `stackit sync`, so by the time a teammate runs
+`stackit get`, the ancestry crawl gives up and the GitHub crawl takes over. PR
+bases carry parents but no revisions, so that path knows no anchors at all.
+
+`harvestAnchors` closes the gap: after whichever crawl ran, it reads
+`ParentBranchRevision` out of the remote metadata cache for every branch in the
+sync set that does not have one yet. The child's own metadata ref is still on the
+remote, and it is the record that matters.
+
+When nothing anywhere records the tip — a branch pushed by a collaborator who
+does not use stackit, whose parent then landed and was deleted — there is no way
+to tell the landed commits apart from the branch's own. Re-anchoring still
+happens, because tracking a branch against a parent that no longer exists is
+worse. Rebasing does not: `LandedAncestorReport.Unanchored` names those branches,
+`Unfreezable` excludes them, and `get` reports them and leaves them frozen rather
+than offering a rebase that would replay the landed work.
+
+### Re-anchoring is reported, never silent
+
+`get` checks branches out **frozen** by default: a frozen branch mirrors the
+remote and restack resets it rather than rebasing it. So re-anchoring moves the
+parent pointer while the branch keeps carrying the landed commits, and restack
+will not fix that on its own.
+
+`get` says so and offers the remedy — unfreeze the affected branches so this run
+rebases them onto the new parent. Declining is a valid answer, not a failure:
+the branch goes on mirroring the remote, correctly tracked, and `st unfreeze`
+plus `st restack` finishes the job later.
+
+The offer is only ever made for branches `get` can actually rebase: frozen (so
+restack skips them as things stand) and anchored (so the rebase drops the landed
+commits rather than replaying them). It is also only made when the run has a
+restack phase to feed — unfreezing under `--no-restack` would drop the protection
+and rebase nothing.
+
 ## The un-pushed trunk guard
 
 Restack rebases trunk-anchored branches onto the **local trunk tip**. In a
@@ -266,6 +351,10 @@ expensive per-commit patch-id walk on every merge check.
 | Non-stackit collaborator squash/rebase, including fully untracked parent | `internal/integration/restack_untracked_collaborator_test.go` |
 | Multi-commit squash with stale/absent PR state, conflict-abort, reflog | `internal/integration/restack_squash_merge_test.go`, `internal/integration/restack_squash_conflict_abort_test.go` |
 | Un-pushed/diverged trunk guard (integration) | `internal/integration/restack_trunk_guard_test.go` |
+| `get` past a parent that landed and left the remote (all merge methods) | `internal/integration/get_landed_parent_test.go` |
+| Same, with the landed parent's remote metadata already cleaned up | `internal/integration/get_landed_parent_test.go` (`TestGetPastLandedParentWithoutParentMetadata`) |
+| Same, with no stackit metadata at all — reported, never rebased | `internal/integration/get_landed_parent_test.go` (`TestGetPastLandedParentWithNoMetadataAtAll`) |
+| Re-anchor target selection, anchor harvesting, report views (actions unit) | `internal/actions/get_internal_test.go` |
 | `TrunkRemoteState` predicate (engine unit) | `internal/engine/engine_impl_test.go` (`TestTrunkRemoteState`) |
 
 When changing any of detection, reparenting, or the guard, cover **all three
@@ -283,3 +372,7 @@ matches it.
 | Reparent target selection | `internal/engine/engine_internal.go` (`shouldReparentBranch`, `findNearestValidAncestor`) |
 | Trunk-remote state | `internal/engine/engine_branch_status.go` (`TrunkRemoteState`) |
 | Restack guard | `internal/actions/restack.go` (`guardUnpushedTrunk`) |
+| Fetch recovery and re-anchoring in `get` | `internal/actions/get.go` (`reanchorPastLanded`) |
+| Remote branch existence | `internal/engine/engine_branch_status.go` (`MissingRemoteBranches`) |
+| Divergence anchor for a fetched branch | `internal/engine/branch_tracking.go` (`TrackBranchPastLandedParent`) |
+| Anchor recovery when the crawl gave up | `internal/actions/get.go` (`harvestAnchors`) |

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/internal/utils"
@@ -60,6 +61,92 @@ type GetSummary struct {
 	UpToDate        bool   // Everything was already current
 }
 
+// Reanchored records a branch whose recorded parent has landed and been deleted
+// on the remote, along with the surviving ancestor it was tracked against
+// instead. The branch's content is untouched: it still carries the landed
+// parent's commits until it is restacked.
+type Reanchored struct {
+	// Branch is the branch that was tracked against a substitute parent.
+	Branch string
+	// LandedParent is the parent recorded on the remote, now gone from it.
+	LandedParent string
+	// LandedPR is the landed parent's PR number, when metadata recorded one.
+	LandedPR *int
+	// NewParent is the nearest surviving ancestor, often trunk.
+	NewParent string
+	// Anchor is the landed parent's tip at the time this branch was pushed, as
+	// recorded in the branch's own remote metadata. It is what lets a later
+	// restack replay only the branch's own commits. Empty when nothing on the
+	// remote recorded it, which makes the branch unsafe to rebase — see
+	// LandedAncestorReport.Unanchored.
+	Anchor string
+}
+
+// StaleBranch is a branch this run leaves sitting on a landed ancestor's
+// commits, together with what get is able to do about it.
+type StaleBranch struct {
+	// Name is the branch.
+	Name string
+	// Frozen reports whether this run leaves the branch frozen. A frozen branch
+	// mirrors the remote and restack resets rather than rebases it, so it stays
+	// stale until something unfreezes it.
+	Frozen bool
+	// Anchored reports whether the re-anchored branch at the root of this
+	// branch's subtree recorded a divergence anchor. Without one, rebasing
+	// replays the landed commits instead of dropping them.
+	Anchored bool
+}
+
+// LandedAncestorReport describes every branch get re-anchored past landed work
+// in this run, and whether get is in a position to offer to rebase them now.
+type LandedAncestorReport struct {
+	// Reanchored lists the substitutions get made, trunk-first.
+	Reanchored []Reanchored
+	// Stale lists every branch left carrying the landed commits — the
+	// re-anchored branches plus their descendants in this run — trunk-first.
+	Stale []StaleBranch
+	// CanRestack is false when restacking is disabled for this run, leaving
+	// nothing to offer.
+	CanRestack bool
+}
+
+// Unfreezable returns the stale branches get can offer to rebase: frozen, so
+// restack skips them as things stand, and anchored, so a rebase drops the
+// landed commits rather than replaying them. Trunk-first.
+func (r LandedAncestorReport) Unfreezable() []string {
+	return r.staleNames(func(b StaleBranch) bool { return b.Frozen && b.Anchored })
+}
+
+// Unanchored returns the stale branches with no recorded divergence anchor.
+// get cannot offer to rebase these — the replay range would still include the
+// landed parent's commits — so they go on mirroring the remote. Trunk-first.
+func (r LandedAncestorReport) Unanchored() []string {
+	return r.staleNames(func(b StaleBranch) bool { return !b.Anchored })
+}
+
+func (r LandedAncestorReport) staleNames(match func(StaleBranch) bool) []string {
+	var names []string
+	for _, b := range r.Stale {
+		if match(b) {
+			names = append(names, b.Name)
+		}
+	}
+	return names
+}
+
+// LandedAncestorDecision is a handler's answer to ReportLandedAncestors.
+type LandedAncestorDecision int
+
+const (
+	// LeaveFrozen keeps the re-anchored branches mirroring the remote. They go
+	// on carrying the landed commits until something unfreezes and rebases
+	// them, which is a valid answer rather than a failure.
+	LeaveFrozen LandedAncestorDecision = iota
+	// UnfreezeAndRestack unfreezes the branches this run can safely rebase, so
+	// the restack phase drops the landed commits.
+	UnfreezeAndRestack
+)
+
 // GetHandler abstracts TTY vs non-TTY output for get operations
 // It embeds RestackHandler to provide consistent output for restack phase
 type GetHandler interface {
@@ -68,6 +155,12 @@ type GetHandler interface {
 
 	// EmitEvent is called for each progress update
 	EmitEvent(event GetEvent)
+
+	// ReportLandedAncestors explains that branches were re-anchored past an
+	// ancestor that landed and left the remote, and asks whether to unfreeze
+	// the ones get can safely rebase (report.Unfreezable) so this run rebases
+	// them onto their new parent.
+	ReportLandedAncestors(report LandedAncestorReport) (LandedAncestorDecision, error)
 
 	// Complete is called when get finishes with the summary
 	Complete(summary GetSummary)
@@ -88,6 +181,12 @@ func (h *GetNullHandler) Start(_ string, _ *int) {}
 // EmitEvent implements GetHandler.
 func (h *GetNullHandler) EmitEvent(_ GetEvent) {}
 
+// ReportLandedAncestors implements GetHandler. Declines to unfreeze, which
+// leaves the fetched branches mirroring the remote.
+func (h *GetNullHandler) ReportLandedAncestors(_ LandedAncestorReport) (LandedAncestorDecision, error) {
+	return LeaveFrozen, nil
+}
+
 // Complete implements GetHandler.
 func (h *GetNullHandler) Complete(_ GetSummary) {}
 
@@ -101,12 +200,25 @@ type GetOptions struct {
 
 // syncTargets is the evolving set of branches fetched by get, along with the
 // parent and PR metadata discovered while walking their ancestry.
+//
+// It is the single source of truth for a run. GetAction reads through it rather
+// than aliasing its fields into locals, so that a rewrite — reanchorPastLanded
+// replacing a landed parent — is visible everywhere at once.
 type syncTargets struct {
-	branches       []string
+	// branches is every branch to sync, trunk-first.
+	branches []string
+	// parentByBranch is the parent to record for each branch.
 	parentByBranch map[string]string
-	prByBranch     map[string]*int
-	// Full PR records for branches resolved through GitHub, so the details
-	// already paid for are recorded rather than reduced to a number.
+	// prByBranch is each branch's PR number, where one is known.
+	prByBranch map[string]*int
+	// anchorByBranch is the parent tip each branch was pushed on top of, read
+	// from its remote metadata's ParentBranchRevision. It is the divergence
+	// anchor when a parent has to be substituted, and it stays reachable from
+	// the branch itself even once the parent's ref is gone from the remote.
+	anchorByBranch map[string]string
+	// prInfoByBranch holds full PR records for branches resolved through
+	// GitHub, so the details already paid for are recorded rather than reduced
+	// to a number.
 	prInfoByBranch map[string]*engine.PrInfo
 }
 
@@ -115,7 +227,49 @@ func newSyncTargets(targetBranch string) *syncTargets {
 		branches:       []string{targetBranch},
 		parentByBranch: make(map[string]string),
 		prByBranch:     make(map[string]*int),
+		anchorByBranch: make(map[string]string),
 		prInfoByBranch: make(map[string]*engine.PrInfo),
+	}
+}
+
+// appendBranches adds branches to the end of the sync set, skipping any already
+// present.
+func (targets *syncTargets) appendBranches(names ...string) {
+	for _, name := range names {
+		if !slices.Contains(targets.branches, name) {
+			targets.branches = append(targets.branches, name)
+		}
+	}
+}
+
+// remoteMetadataLookup reads fetched remote metadata by branch name.
+// engine.RemoteMetadataView satisfies it.
+type remoteMetadataLookup interface {
+	Get(branch string) *git.Meta
+}
+
+// harvestAnchors records a divergence anchor for every branch whose remote
+// metadata carries one and that does not have one already.
+//
+// crawlAncestorsViaMetadata collects these as it walks, but it abandons the
+// whole walk the moment one ancestor has no metadata — which is exactly the
+// state a merged parent is left in, since branch cleanup deletes a merged
+// branch's remote metadata ref during the author's own sync. The GitHub crawl
+// that takes over records parents but knows no revisions, so without this pass
+// the branch below the landed one is re-anchored with no anchor at all and a
+// later restack replays the landed commits into it.
+func (targets *syncTargets) harvestAnchors(view remoteMetadataLookup) {
+	for _, name := range targets.branches {
+		if _, ok := targets.anchorByBranch[name]; ok {
+			continue
+		}
+		meta := view.Get(name)
+		if meta == nil {
+			continue
+		}
+		if rev := meta.GetParentBranchRevision(); rev != nil && *rev != "" {
+			targets.anchorByBranch[name] = *rev
+		}
 	}
 }
 
@@ -196,12 +350,10 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	if !usedMetadata {
 		targets.crawlAncestorsViaGitHub(remoteCtx, ctx.GitHub(), eng, targetBranch)
 	}
-	branchesToSync := targets.branches
-	parentMap := targets.parentByBranch
-	branchPRInfo := targets.prByBranch
-	// Full PR records for every branch whose PR we resolved, persisted after the
-	// sync loop so the branches carry GitHub state immediately.
-	fetchedPRs := targets.prInfoByBranch
+	// Either crawl can leave a branch without its divergence anchor: the GitHub
+	// one never reads them, and the metadata one abandons a partial chain. Fill
+	// in whatever the remote metadata does have before anything relies on it.
+	targets.harvestAnchors(eng.GetRemoteMetadataCache())
 
 	// If target branch exists locally, identify local descendants
 	targetBranchObj := eng.GetBranch(targetBranch)
@@ -209,9 +361,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		graph := eng.Graph(engine.SortStrategyAlphabetical)
 		upstack := graph.Range(targetBranchObj, engine.StackRange{RecursiveChildren: true})
 		for _, b := range upstack {
-			if !slices.Contains(branchesToSync, b.GetName()) {
-				branchesToSync = append(branchesToSync, b.GetName())
-			}
+			targets.appendBranches(b.GetName())
 		}
 	}
 
@@ -219,9 +369,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// wildcard already came down in the first fetch, so this only needs branch heads. The
 	// target was fetched above, so it is pre-seeded as seen and skipped here. For a single
 	// branch whose parent is trunk this list is empty, leaving exactly one fetch total.
-	branchesToFetch := make([]string, 0, len(branchesToSync))
+	branchesToFetch := make([]string, 0, len(targets.branches))
 	seenFetchBranch := map[string]bool{targetBranch: true}
-	for _, branchName := range branchesToSync {
+	for _, branchName := range targets.branches {
 		if branchName == trunkName && branchName != targetBranch {
 			continue
 		}
@@ -232,12 +382,44 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		branchesToFetch = append(branchesToFetch, branchName)
 	}
 
+	var reanchored map[string]Reanchored
 	if len(branchesToFetch) > 0 {
 		if err := eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
 			Remote:   remote,
 			Branches: branchesToFetch,
 		}); err != nil {
-			return fmt.Errorf("failed to fetch branches from %s: %w", remote, err)
+			// Explicit refspecs are all-or-nothing: one ancestor that landed and
+			// had its branch deleted fails the whole fetch, so the branch the
+			// user actually asked for never arrives. Find out which of the
+			// requested branches are gone, drop them, and fetch the rest. The
+			// ls-remote only runs on this error path, so a healthy stack still
+			// costs one round trip.
+			gone, lsErr := eng.MissingRemoteBranches(remoteCtx, branchesToFetch)
+			if lsErr != nil || len(gone) == 0 {
+				return fmt.Errorf("failed to fetch branches from %s: %w", remote, err)
+			}
+			out.Debug("branches no longer on %s: %v", remote, gone)
+
+			stillOnRemote := make([]string, 0, len(branchesToFetch))
+			for _, branchName := range branchesToFetch {
+				if !slices.Contains(gone, branchName) {
+					stillOnRemote = append(stillOnRemote, branchName)
+				}
+			}
+			if len(stillOnRemote) > 0 {
+				if retryErr := eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
+					Remote:   remote,
+					Branches: stillOnRemote,
+				}); retryErr != nil {
+					return fmt.Errorf("failed to fetch branches from %s: %w", remote, retryErr)
+				}
+			}
+
+			// A gone branch that is still checked out locally keeps its children;
+			// only one that is gone from both sides forces a substitute parent.
+			// The engine already holds every local branch name, so this decision
+			// never has to fall back to a guess.
+			reanchored = targets.reanchorPastLanded(eng.BranchNames(), gone, trunkName)
 		}
 	}
 
@@ -256,17 +438,16 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 
 	// Track statistics for summary
 	var branchesCreated, branchesUpdated int
-	branchFrozenStatus := make(map[string]bool) // branch -> is frozen
-	branchesToFreeze := engine.NewBranchesBuilder(len(branchesToSync))
+	branchesToFreeze := engine.NewBranchesBuilder(len(targets.branches))
 
 	// Fetch PR info for branches in parallel if possible
 	if ctx.GitHub() != nil {
 		trunkName := eng.Trunk().GetName()
 
 		// Filter out trunk before parallel fetch
-		branchesToFetch := make([]string, 0, len(branchesToSync))
-		for _, branchName := range branchesToSync {
-			if _, ok := branchPRInfo[branchName]; ok {
+		branchesToFetch := make([]string, 0, len(targets.branches))
+		for _, branchName := range targets.branches {
+			if _, ok := targets.prByBranch[branchName]; ok {
 				continue
 			}
 			if branchName != trunkName {
@@ -284,15 +465,15 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				// until the next sync repeats the same fetch.
 				info := engine.NewPrInfo(&prNum, pr.Title, pr.Body, pr.State, pr.Base, pr.HTMLURL, pr.Draft)
 				mu.Lock()
-				branchPRInfo[branchName] = &prNum
-				fetchedPRs[branchName] = info
+				targets.prByBranch[branchName] = &prNum
+				targets.prInfoByBranch[branchName] = info
 				mu.Unlock()
 			}
 		})
 	}
 
 	// Sync each branch
-	for _, branchName := range branchesToSync {
+	for _, branchName := range targets.branches {
 		if branchName == eng.Trunk().GetName() {
 			continue
 		}
@@ -304,16 +485,27 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			if err := eng.CreateBranch(gctx, branchName, fmt.Sprintf("%s/%s", remote, branchName)); err != nil {
 				return fmt.Errorf("failed to create local branch %s: %w", branchName, err)
 			}
-			// Set initial metadata
-			if parent, ok := parentMap[branchName]; ok {
-				if err := eng.TrackBranch(gctx, branchName, parent); err != nil {
+			// Set initial metadata. A branch re-anchored past a landed parent is
+			// tracked through TrackBranchPastLandedParent so the parent it was
+			// actually pushed on top of anchors the divergence point; tracking it
+			// straight against the substitute would take a merge-base that puts
+			// the landed commits back into a later restack's replay range.
+			if parent, ok := targets.parentByBranch[branchName]; ok {
+				var err error
+				if landed, ok := reanchored[branchName]; ok {
+					err = eng.TrackBranchPastLandedParent(gctx, branchName, parent, engine.PriorParent{
+						Branch:   landed.LandedParent,
+						Revision: landed.Anchor,
+					})
+				} else {
+					err = eng.TrackBranch(gctx, branchName, parent)
+				}
+				if err != nil {
 					out.Debug("Failed to track branch %s with parent %s: %v", branchName, parent, err)
 				}
 			}
 			// New branches are frozen by default unless --unfrozen
-			isFrozen := !opts.Unfrozen
-			branchFrozenStatus[branchName] = isFrozen
-			if isFrozen {
+			if !opts.Unfrozen {
 				branchesToFreeze.Add(eng.GetBranch(branchName))
 			}
 			branchesCreated++
@@ -323,7 +515,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				Phase:    GetPhaseSync,
 				Type:     GetEventCompleted,
 				Branch:   branchName,
-				PRNumber: branchPRInfo[branchName],
+				PRNumber: targets.prByBranch[branchName],
 				IsNew:    true,
 			})
 		} else {
@@ -347,7 +539,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			}
 			// Update parent if known, preserving the divergence point so that
 			// restacking doesn't carry commits from the old parent.
-			if parent, ok := parentMap[branchName]; ok {
+			if parent, ok := targets.parentByBranch[branchName]; ok {
 				if err := eng.ReparentBranch(gctx, branch, eng.GetBranch(parent)); err != nil {
 					out.Debug("Failed to update parent for %s: %v", branchName, err)
 				}
@@ -359,13 +551,38 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				Phase:    GetPhaseSync,
 				Type:     GetEventCompleted,
 				Branch:   branchName,
-				PRNumber: branchPRInfo[branchName],
+				PRNumber: targets.prByBranch[branchName],
 				IsNew:    false,
 			})
 		}
 	}
 
-	if freezeSet := branchesToFreeze.Build(); len(freezeSet) > 0 {
+	freezeSet := branchesToFreeze.Build()
+
+	// Re-anchoring only corrects which parent a branch is recorded against. The
+	// branch still carries the landed parent's commits until it is rebased, and
+	// a frozen branch is never rebased — restack skips it and resets it to the
+	// remote instead. Explain that, and let the user opt into unfreezing so the
+	// restack phase below can finish the job.
+	if len(reanchored) > 0 {
+		report := LandedAncestorReport{
+			Reanchored: targets.reanchoredInSyncOrder(reanchored),
+			Stale:      targets.staleAfterReanchor(eng, reanchored, freezeSet),
+			CanRestack: opts.Restack,
+		}
+		decision, err := handler.ReportLandedAncestors(report)
+		if err != nil {
+			out.Debug("Landed-ancestor prompt failed: %v", err)
+		}
+		// Unfreezing is only worth anything because the restack phase below acts
+		// on it. Without that phase it would drop the protection and rebase
+		// nothing, so act on the decision only when there is a restack to feed.
+		if decision == UnfreezeAndRestack && opts.Restack {
+			freezeSet = unfreezeForRestack(ctx, report.Unfreezable(), freezeSet)
+		}
+	}
+
+	if len(freezeSet) > 0 {
 		if _, err := eng.SetFrozen(ctx, freezeSet, true); err != nil {
 			out.Debug("Failed to freeze new branches: %v", err)
 		}
@@ -374,15 +591,15 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// Record the PR details fetched above. Without this the branch has no PR
 	// metadata locally, and every consumer that filters on it — `tree full`
 	// most visibly — shows nothing until a later sync refetches the same data.
-	if len(fetchedPRs) > 0 {
-		if err := eng.BatchUpsertPrInfo(gctx, fetchedPRs); err != nil {
+	if len(targets.prInfoByBranch) > 0 {
+		if err := eng.BatchUpsertPrInfo(gctx, targets.prInfoByBranch); err != nil {
 			out.Debug("Failed to record PR info: %v", err)
 		}
 	}
 
 	// FetchRemote above already brought metadata refs local; apply any matching
 	// remote metadata to the branches we synced.
-	if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, branchesToSync); err != nil {
+	if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, targets.branches); err != nil {
 		out.Debug("Failed to apply remote metadata: %v", err)
 	}
 
@@ -395,9 +612,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	var restacked, skipped int
 	var conflicts, blocked []string
 	if opts.Restack {
-		uniqueBranches := engine.NewBranchesBuilder(len(branchesToSync))
+		uniqueBranches := engine.NewBranchesBuilder(len(targets.branches))
 		seen := make(map[string]bool)
-		for _, name := range branchesToSync {
+		for _, name := range targets.branches {
 			if !seen[name] {
 				seen[name] = true
 				b := eng.GetBranch(name)
@@ -415,7 +632,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				// Prefer the PR number discovered during sync (which may have come
 				// from remote metadata not copied into local metadata); fall back to
 				// local metadata otherwise.
-				prNumber := branchPRInfo[p.Branch]
+				prNumber := targets.prByBranch[p.Branch]
 				if prNumber == nil {
 					prNumber = PRNumberForBranch(eng, p.Branch)
 				}
@@ -485,10 +702,188 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	return nil
 }
 
+// localBranchSet reports whether a branch name exists locally. engine.BranchSet
+// satisfies it; tests pass a plain set.
+type localBranchSet interface {
+	Contains(name string) bool
+}
+
+// reanchorPastLanded drops the branches that are gone from the remote out of
+// the sync set and re-points the children they left behind at the nearest
+// surviving ancestor, returning the substitutions keyed by branch name.
+//
+// A branch that stackit metadata still names as a parent but that no longer has
+// a ref on the remote has landed: it was pushed once, its commits are on trunk
+// under new SHAs, and there is nothing left to fetch. Its children are still
+// fetchable, and the nearest ancestor that does exist is the only coherent
+// parent left to record for them.
+//
+// A gone branch that still exists locally keeps its children: it is a real
+// branch the user may still be working with, and restack's landed-parent
+// handling already reparents past it.
+func (targets *syncTargets) reanchorPastLanded(localBranches localBranchSet, gone []string, trunkName string) map[string]Reanchored {
+	if len(gone) == 0 {
+		return nil
+	}
+
+	goneSet := make(map[string]bool, len(gone))
+	unavailable := make(map[string]bool, len(gone))
+	for _, name := range gone {
+		goneSet[name] = true
+		if !localBranches.Contains(name) {
+			unavailable[name] = true
+		}
+	}
+
+	remaining := make([]string, 0, len(targets.branches))
+	for _, name := range targets.branches {
+		if !goneSet[name] {
+			remaining = append(remaining, name)
+		}
+	}
+	targets.branches = remaining
+
+	reanchored := make(map[string]Reanchored)
+	for _, name := range remaining {
+		parent, ok := targets.parentByBranch[name]
+		if !ok || !unavailable[parent] {
+			continue
+		}
+		newParent := targets.nearestAvailableAncestor(name, unavailable, trunkName)
+		targets.parentByBranch[name] = newParent
+		reanchored[name] = Reanchored{
+			Branch:       name,
+			LandedParent: parent,
+			LandedPR:     targets.prByBranch[parent],
+			NewParent:    newParent,
+			Anchor:       targets.anchorByBranch[name],
+		}
+	}
+
+	return reanchored
+}
+
+// reanchoredInSyncOrder returns the substitutions trunk-first, matching the
+// order the branches are synced in. The map is the working form; this is the
+// reporting form.
+func (targets *syncTargets) reanchoredInSyncOrder(reanchored map[string]Reanchored) []Reanchored {
+	ordered := make([]Reanchored, 0, len(reanchored))
+	for _, name := range targets.branches {
+		if r, ok := reanchored[name]; ok {
+			ordered = append(ordered, r)
+		}
+	}
+	return ordered
+}
+
+// nearestAvailableAncestor walks up branchName's recorded ancestry until it
+// reaches a branch that is still available, falling back to trunk.
+func (targets *syncTargets) nearestAvailableAncestor(branchName string, unavailable map[string]bool, trunkName string) string {
+	seen := map[string]bool{branchName: true}
+	current := branchName
+	for {
+		parent, ok := targets.parentByBranch[current]
+		if !ok || parent == "" || parent == trunkName || seen[parent] {
+			return trunkName
+		}
+		if !unavailable[parent] {
+			return parent
+		}
+		seen[parent] = true
+		current = parent
+	}
+}
+
+// staleAfterReanchor returns every branch this run leaves sitting on landed
+// commits — each re-anchored branch plus its descendants within the sync set —
+// in sync order, along with what get can do about each.
+//
+// Descendants are included because none of them are clean until the whole
+// subtree is rebased onto the new parent, and they inherit their subtree root's
+// anchor: with no anchor for the root, rebasing anything above it replays the
+// landed commits too.
+//
+// pendingFreeze is the set queued to be frozen once the sync loop finishes, so
+// that a branch created moments ago counts as frozen alongside one that already
+// was.
+func (targets *syncTargets) staleAfterReanchor(eng engine.Engine, reanchored map[string]Reanchored, pendingFreeze engine.Branches) []StaleBranch {
+	inSync := make(map[string]bool, len(targets.branches))
+	for _, name := range targets.branches {
+		inSync[name] = true
+	}
+
+	graph := eng.Graph(engine.SortStrategyAlphabetical)
+	anchored := make(map[string]bool, len(reanchored))
+	mark := func(name string, hasAnchor bool) {
+		if !inSync[name] {
+			return
+		}
+		// A branch has one parent, so it belongs to one re-anchored subtree.
+		// Should that ever stop holding, the unanchored answer is the safe one.
+		if prev, seen := anchored[name]; seen && !prev {
+			return
+		}
+		anchored[name] = hasAnchor
+	}
+
+	for _, r := range reanchored {
+		hasAnchor := r.Anchor != ""
+		// Mark the branch itself first: a branch that failed to track has no
+		// place in the graph, and it is still the one carrying landed commits.
+		mark(r.Branch, hasAnchor)
+		for _, b := range graph.Range(eng.GetBranch(r.Branch), engine.StackRange{RecursiveChildren: true}) {
+			mark(b.GetName(), hasAnchor)
+		}
+	}
+
+	stale := make([]StaleBranch, 0, len(anchored))
+	for _, name := range targets.branches {
+		hasAnchor, ok := anchored[name]
+		if !ok {
+			continue
+		}
+		stale = append(stale, StaleBranch{
+			Name:     name,
+			Frozen:   pendingFreeze.Contains(name) || eng.GetBranch(name).IsFrozen(),
+			Anchored: hasAnchor,
+		})
+	}
+	return stale
+}
+
+// unfreezeForRestack thaws the named branches so the restack phase can rebase
+// them, and returns pendingFreeze with those branches removed so the freeze
+// that follows does not put them straight back.
+func unfreezeForRestack(ctx *app.Context, names []string, pendingFreeze engine.Branches) engine.Branches {
+	if len(names) == 0 {
+		return pendingFreeze
+	}
+
+	unfreezing := make(map[string]bool, len(names))
+	for _, name := range names {
+		unfreezing[name] = true
+	}
+
+	eng := ctx.Engine
+	thaw := engine.NewBranchesBuilder(len(names))
+	for _, name := range names {
+		if branch := eng.GetBranch(name); branch.IsFrozen() {
+			thaw.Add(branch)
+		}
+	}
+	if thawSet := thaw.Build(); len(thawSet) > 0 {
+		if _, err := eng.SetFrozen(ctx, thawSet, false); err != nil {
+			ctx.Output.Debug("Failed to unfreeze branches re-anchored past landed work: %v", err)
+		}
+	}
+
+	return pendingFreeze.Filter(func(b engine.Branch) bool { return !unfreezing[b.GetName()] })
+}
+
 // crawlAncestorsViaMetadata walks the parent chain of targetBranch using the fetched
 // remote metadata cache (refs/stackit/remote-metadata/*), avoiding GitHub calls. It
-// prepends discovered ancestors to branchesToSync (trunk-first) and records each branch's
-// parent in parentMap and any known PR number in branchPRInfo. The second return value
+// prepends discovered ancestors to the sync set (trunk-first) and records each branch's
+// parent, divergence anchor, and any known PR number on targets. The return value
 // reports whether the target had usable metadata; when false the caller should fall back
 // to a GitHub crawl. Callers must have populated the cache via LoadRemoteMetadataCache.
 func (targets *syncTargets) crawlAncestorsViaMetadata(eng engine.Engine, targetBranch string) bool {
@@ -503,6 +898,7 @@ func (targets *syncTargets) crawlAncestorsViaMetadata(eng engine.Engine, targetB
 	discoveredBranches := slices.Clone(targets.branches)
 	discoveredParents := make(map[string]string)
 	discoveredPRs := make(map[string]*int)
+	discoveredAnchors := make(map[string]string)
 
 	current := targetBranch
 	for {
@@ -514,6 +910,9 @@ func (targets *syncTargets) crawlAncestorsViaMetadata(eng engine.Engine, targetB
 		}
 		if pr := meta.GetPrInfo(); pr != nil && pr.Number != nil {
 			discoveredPRs[current] = pr.Number
+		}
+		if rev := meta.GetParentBranchRevision(); rev != nil && *rev != "" {
+			discoveredAnchors[current] = *rev
 		}
 
 		parent := meta.GetParentBranchName()
@@ -532,17 +931,18 @@ func (targets *syncTargets) crawlAncestorsViaMetadata(eng engine.Engine, targetB
 
 	maps.Copy(targets.parentByBranch, discoveredParents)
 	maps.Copy(targets.prByBranch, discoveredPRs)
+	maps.Copy(targets.anchorByBranch, discoveredAnchors)
 	targets.branches = discoveredBranches
 	return true
 }
 
 // crawlAncestorsViaGitHub walks the parent chain of targetBranch using GitHub PR
-// information. It prepends discovered ancestors to branchesToSync (trunk-first) and
-// records each branch's parent in parentMap and PR number in branchPRInfo. It is a
-// no-op when no GitHub client is configured. The (possibly grown) branchesToSync slice
-// is returned because ancestors are prepended. The context bounds the GitHub reads; it
-// takes the narrow github.Client/engine.Engine it needs rather than the full app
-// context, so the unbounded command context is not reachable here by mistake.
+// information. It prepends discovered ancestors to the sync set (trunk-first) and
+// records each branch's parent and PR number on targets. It is a no-op when no GitHub
+// client is configured. PR bases carry no revisions, so the anchors it leaves behind
+// come from harvestAnchors instead. The context bounds the GitHub reads; it takes the
+// narrow github.Client/engine.Engine it needs rather than the full app context, so the
+// unbounded command context is not reachable here by mistake.
 func (targets *syncTargets) crawlAncestorsViaGitHub(ctx context.Context, gh github.Client, eng engine.Engine, targetBranch string) {
 	if gh == nil {
 		return

--- a/internal/actions/get_internal_test.go
+++ b/internal/actions/get_internal_test.go
@@ -1,0 +1,211 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// remoteMetadata is a remoteMetadataLookup for tests, standing in for the
+// engine's cache of metadata refs fetched from the remote.
+type remoteMetadata map[string]*git.Meta
+
+func (m remoteMetadata) Get(branch string) *git.Meta { return m[branch] }
+
+// localBranches is a localBranchSet for tests, standing in for the engine's
+// cached list of every branch that exists in refs/heads.
+type localBranches []string
+
+func (l localBranches) Contains(name string) bool {
+	for _, b := range l {
+		if b == name {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestTargets(parents map[string]string, branches []string) *syncTargets {
+	targets := newSyncTargets(branches[len(branches)-1])
+	targets.branches = branches
+	for branch, parent := range parents {
+		targets.parentByBranch[branch] = parent
+	}
+	return targets
+}
+
+// reanchorPastLanded decides which parent a fetched branch is recorded against
+// when ancestors have disappeared from the remote. The walk has to skip a run
+// of landed ancestors rather than stopping at the first one, and has to leave
+// alone a parent that is gone from the remote but still checked out locally.
+func TestReanchorPastLanded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("re-anchors onto trunk when the whole downstack has landed", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{
+			"a": "main",
+			"b": "a",
+			"c": "b",
+		}, []string{"a", "b", "c"})
+
+		reanchored := targets.reanchorPastLanded(localBranches(nil), []string{"a", "b"}, "main")
+
+		require.Equal(t, []string{"c"}, targets.branches, "landed branches drop out of the sync set")
+		require.Len(t, reanchored, 1)
+		require.Equal(t, "c", reanchored["c"].Branch)
+		require.Equal(t, "b", reanchored["c"].LandedParent)
+		require.Equal(t, "main", reanchored["c"].NewParent)
+		require.Equal(t, "main", targets.parentByBranch["c"])
+	})
+
+	t.Run("re-anchors onto the nearest ancestor that survives", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{
+			"a": "main",
+			"b": "a",
+			"c": "b",
+		}, []string{"a", "b", "c"})
+
+		reanchored := targets.reanchorPastLanded(localBranches(nil), []string{"b"}, "main")
+
+		require.Equal(t, []string{"a", "c"}, targets.branches)
+		require.Len(t, reanchored, 1)
+		require.Equal(t, "a", reanchored["c"].NewParent, "a is still on the remote, so c belongs under it")
+		require.Equal(t, "a", targets.parentByBranch["c"])
+	})
+
+	t.Run("leaves a parent that still exists locally as the parent", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{
+			"a": "main",
+			"b": "a",
+		}, []string{"a", "b"})
+
+		reanchored := targets.reanchorPastLanded(localBranches{"main", "a", "b"}, []string{"a"}, "main")
+
+		require.Equal(t, []string{"b"}, targets.branches, "a cannot be fetched, so it leaves the sync set either way")
+		require.Empty(t, reanchored, "restack reparents past a landed local parent on its own")
+		require.Equal(t, "a", targets.parentByBranch["b"])
+	})
+
+	t.Run("stops at trunk when the ancestry chain is incomplete", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{"b": "a"}, []string{"b"})
+
+		reanchored := targets.reanchorPastLanded(localBranches(nil), []string{"a"}, "main")
+
+		require.Len(t, reanchored, 1)
+		require.Equal(t, "main", reanchored["b"].NewParent)
+	})
+
+	t.Run("is a no-op when every branch is still on the remote", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{"a": "main", "b": "a"}, []string{"a", "b"})
+
+		reanchored := targets.reanchorPastLanded(localBranches(nil), nil, "main")
+
+		require.Equal(t, []string{"a", "b"}, targets.branches)
+		require.Empty(t, reanchored)
+	})
+
+	// Two ancestors landing at different times leaves two substitutions with
+	// different new parents. Nothing downstream may assume they share one.
+	t.Run("records each substitution when two ancestors have landed", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{
+			"a": "main",
+			"b": "a",
+			"c": "b",
+			"d": "c",
+		}, []string{"a", "b", "c", "d"})
+
+		reanchored := targets.reanchorPastLanded(localBranches(nil), []string{"a", "c"}, "main")
+
+		require.Equal(t, []string{"b", "d"}, targets.branches)
+		require.Len(t, reanchored, 2)
+		require.Equal(t, "main", reanchored["b"].NewParent)
+		require.Equal(t, "b", reanchored["d"].NewParent, "d belongs under the surviving b, not trunk")
+		require.Equal(t, []string{"b", "d"},
+			[]string{targets.reanchoredInSyncOrder(reanchored)[0].Branch, targets.reanchoredInSyncOrder(reanchored)[1].Branch},
+			"the report is ordered trunk-first, not by map iteration")
+	})
+
+	// The anchor is what lets a later restack replay only the branch's own
+	// commits, so it has to be carried into the record the sync loop reads.
+	t.Run("carries the divergence anchor into the record", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{"a": "main", "b": "a"}, []string{"a", "b"})
+		targets.anchorByBranch["b"] = "deadbeef"
+
+		reanchored := targets.reanchorPastLanded(localBranches(nil), []string{"a"}, "main")
+
+		require.Equal(t, "deadbeef", reanchored["b"].Anchor)
+	})
+}
+
+// harvestAnchors is the fallback that keeps a branch rebasable when the
+// metadata crawl gave up. The crawl abandons the whole walk as soon as one
+// ancestor has no metadata — which is the state a merged parent is left in,
+// since branch cleanup deletes its remote metadata ref — and the GitHub crawl
+// that takes over reads PR bases, which carry no revisions.
+func TestHarvestAnchors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fills in anchors the crawl did not record", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{"b": "a"}, []string{"a", "b"})
+
+		targets.harvestAnchors(remoteMetadata{
+			"b": git.NewMeta().WithParentBranchRevision(strPtr("cafe1234")),
+		})
+
+		require.Equal(t, "cafe1234", targets.anchorByBranch["b"])
+	})
+
+	t.Run("leaves an anchor the crawl already recorded", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{"b": "a"}, []string{"b"})
+		targets.anchorByBranch["b"] = "fromcrawl"
+
+		targets.harvestAnchors(remoteMetadata{
+			"b": git.NewMeta().WithParentBranchRevision(strPtr("fromcache")),
+		})
+
+		require.Equal(t, "fromcrawl", targets.anchorByBranch["b"])
+	})
+
+	t.Run("records nothing when the remote metadata has no revision", func(t *testing.T) {
+		t.Parallel()
+		targets := newTestTargets(map[string]string{"b": "a"}, []string{"b"})
+
+		targets.harvestAnchors(remoteMetadata{
+			"b": git.NewMeta(),
+		})
+
+		require.Empty(t, targets.anchorByBranch)
+	})
+}
+
+// The report's two views are what the CLI and the action both key off: only a
+// frozen branch with an anchor can be offered, and an unanchored one has to be
+// called out instead of silently left behind.
+func TestLandedAncestorReportViews(t *testing.T) {
+	t.Parallel()
+
+	report := LandedAncestorReport{
+		Stale: []StaleBranch{
+			{Name: "frozen-anchored", Frozen: true, Anchored: true},
+			{Name: "thawed-anchored", Frozen: false, Anchored: true},
+			{Name: "frozen-unanchored", Frozen: true, Anchored: false},
+		},
+	}
+
+	require.Equal(t, []string{"frozen-anchored"}, report.Unfreezable(),
+		"an already-thawed branch needs no offer, and an unanchored one must not get it")
+	require.Equal(t, []string{"frozen-unanchored"}, report.Unanchored())
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/cli/branch/get.go
+++ b/internal/cli/branch/get.go
@@ -27,7 +27,16 @@ to opt out of this behavior, use the --downstack flag.
 
 Note that remote-only branches upstack of the branch are not currently synced. 
 
-If no branch is provided, sync the current stack.`,
+If an ancestor has merged and its branch was deleted on the remote, get tracks
+what is left against the nearest branch that still exists and offers to unfreeze
+and restack it, since a frozen branch keeps the landed commits until it is rebased.
+
+If no branch is provided, sync the current stack.
+
+Examples:
+  stackit get 123           # Sync the stack for PR #123
+  stackit get my-branch     # Sync the stack down to my-branch
+  stackit get -U my-branch  # ...and leave the fetched branches editable`,
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -1,6 +1,7 @@
 package branch
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -59,6 +60,101 @@ func (h *SimpleGetHandler) EmitEvent(event actions.GetEvent) {
 
 	// Handle progress events
 	h.printEventLine(event)
+}
+
+// describeLandedAncestors writes the human-readable explanation of branches
+// re-anchored past landed work. Split from the prompt so the text is identical
+// whether or not there is a terminal to ask on.
+func describeLandedAncestors(out output.Output, report actions.LandedAncestorReport) {
+	out.Newline()
+	out.Warn("Landed work in this stack is no longer on the remote:")
+	for _, r := range report.Reanchored {
+		out.Info("  • %s%s has landed; %s is now tracked against %s",
+			style.ColorBranchName(r.LandedParent),
+			common.FormatPRInfo(r.LandedPR),
+			style.ColorBranchName(r.Branch),
+			style.ColorBranchName(r.NewParent))
+	}
+
+	// Re-anchoring moved the parent pointer, not the commits. Say so plainly:
+	// a frozen branch mirrors the remote, and restack resets it instead of
+	// rebasing it, so its diff keeps the landed commits until it is unfrozen.
+	if unfreezable := report.Unfreezable(); len(unfreezable) > 0 {
+		out.Newline()
+		out.Info("  %s still %s the landed commits. Frozen branches mirror the remote, so restack won't rebase %s.",
+			formatBranchList(unfreezable),
+			pluralWord(len(unfreezable), "contains", "contain"),
+			actions.PluralIt(len(unfreezable) != 1))
+	}
+
+	// Without the parent tip a branch was pushed on top of, there is nothing to
+	// separate the landed commits from the branch's own, and a rebase replays
+	// them rather than dropping them. Staying frozen is the only safe answer,
+	// so say that rather than pointing at a remedy that would do damage.
+	if unanchored := report.Unanchored(); len(unanchored) > 0 {
+		out.Newline()
+		out.Info("  No record on the remote of the parent tip for %s, so the landed commits can't be separated from %s own work.",
+			formatBranchList(unanchored),
+			pluralWord(len(unanchored), "its", "their"))
+		out.Info("  Left frozen — rebasing by hand would replay the landed work.")
+	}
+}
+
+// ReportLandedAncestors implements GetHandler. Explains the re-anchoring and,
+// when there is something safe to offer and a terminal to ask on, offers to
+// unfreeze the affected branches so this run rebases them.
+func (h *SimpleGetHandler) ReportLandedAncestors(report actions.LandedAncestorReport) (actions.LandedAncestorDecision, error) {
+	h.Lock()
+	defer h.Unlock()
+
+	describeLandedAncestors(h.Output, report)
+
+	unfreezable := report.Unfreezable()
+	if len(unfreezable) == 0 || !report.CanRestack {
+		return actions.LeaveFrozen, nil
+	}
+
+	// Unstyled, and naming the branches rather than a parent: more than one
+	// ancestor can have landed, and then they do not share a new parent.
+	confirmed, err := tui.PromptConfirm(
+		fmt.Sprintf("Unfreeze and restack %s now?", strings.Join(unfreezable, ", ")), false)
+	if err != nil && !errors.Is(err, tui.ErrInteractiveDisabled) {
+		return actions.LeaveFrozen, err
+	}
+	if confirmed {
+		return actions.UnfreezeAndRestack, nil
+	}
+
+	// `st unfreeze` takes one branch and thaws its upstack with it, so naming
+	// the trunk-most branch covers the rest of the subtree.
+	h.Output.Info("  Run %s then %s when you're ready to rebase.",
+		style.ColorCyan("st unfreeze "+unfreezable[0]),
+		style.ColorCyan("st restack"))
+	return actions.LeaveFrozen, nil
+}
+
+// pluralWord picks the singular or plural form for a count of branches.
+func pluralWord(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+// formatBranchList renders branch names for prose: "a", "a and b", "a, b and c".
+func formatBranchList(names []string) string {
+	styled := make([]string, len(names))
+	for i, name := range names {
+		styled[i] = style.ColorBranchName(name)
+	}
+	switch len(styled) {
+	case 0:
+		return ""
+	case 1:
+		return styled[0]
+	default:
+		return strings.Join(styled[:len(styled)-1], ", ") + " and " + styled[len(styled)-1]
+	}
 }
 
 // Complete is called when get finishes

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -70,6 +70,60 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 	return e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(parentBranchName), DivergenceRecompute)
 }
 
+// PriorParent records the parent a branch was built on, as read from a source
+// outside the local repository: stackit metadata fetched from the remote, or a
+// PR base. It carries what SetParent would normally find in existing local
+// metadata for a branch that has none yet.
+type PriorParent struct {
+	// Branch is the name of the parent the branch was built on.
+	Branch string
+	// Revision is that parent's tip at the time the branch was pushed. It is
+	// still reachable from the branch itself even after the parent's ref is
+	// deleted, which is what makes it usable as a divergence anchor.
+	Revision string
+}
+
+// TrackBranchPastLandedParent tracks branchName under parentBranchName when the
+// parent it was actually built on is not available locally — an ancestor that
+// landed and was deleted on the remote before the branch was fetched.
+//
+// Recording prior first is what makes the divergence point correct. SetParent's
+// recompute path keeps an existing parent revision when that revision has
+// landed in the new parent, so a later restack replays only this branch's own
+// commits. Without it the branch starts with no history at all and the
+// merge-base against the new parent is taken instead — which, for every merge
+// method that rewrites SHAs (squash and rebase), puts the landed parent's
+// commits back into the replay range.
+//
+// When prior.Revision has not landed, the recompute path falls back to the
+// merge-base on its own and the branch keeps the abandoned parent's commits.
+func (e *engineImpl) TrackBranchPastLandedParent(ctx context.Context, branchName string, parentBranchName string, prior PriorParent) error {
+	if branchName == e.trunk {
+		return fmt.Errorf("cannot track trunk branch %s", e.trunk)
+	}
+	if branchName == parentBranchName {
+		return fmt.Errorf("branch cannot be its own parent")
+	}
+
+	if prior.Branch != "" && prior.Revision != "" && prior.Branch != branchName {
+		meta, err := e.readMetadata(branchName)
+		if err != nil {
+			meta = git.NewMeta()
+		}
+		meta = meta.WithParentBranchName(&prior.Branch).WithParentBranchRevision(&prior.Revision)
+
+		tx := e.BeginTx(fmt.Sprintf("record prior parent: %s -> %s", branchName, prior.Branch))
+		if err := tx.UpdateMeta(branchName, meta); err != nil {
+			return fmt.Errorf("failed to record prior parent for %s: %w", branchName, err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("failed to record prior parent for %s: %w", branchName, err)
+		}
+	}
+
+	return e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(parentBranchName), DivergenceRecompute)
+}
+
 // UntrackBranch stops tracking a branch by deleting its metadata
 func (e *engineImpl) UntrackBranch(ctx context.Context, branchName string) error {
 	// Delete metadata

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -612,3 +612,35 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 func (e *engineImpl) GetRemote() string {
 	return e.git.GetRemote()
 }
+
+// MissingRemoteBranches returns the subset of branchNames that no longer have a
+// branch ref on the configured remote, preserving the order they were given in.
+// It lists the remote's refs once and mutates nothing locally.
+//
+// Callers use it to recover from an all-or-nothing fetch: an explicit refspec
+// for a deleted branch fails the whole `git fetch`, including the refspecs for
+// branches that do exist. A branch discovered through stackit metadata or a PR
+// base was pushed at some point, so its absence now means it was deleted —
+// nearly always because it landed.
+func (e *engineImpl) MissingRemoteBranches(ctx context.Context, branchNames []string) ([]string, error) {
+	if len(branchNames) == 0 {
+		return nil, nil
+	}
+	remote := e.GetRemote()
+
+	remoteShas, err := e.git.FetchRemoteShas(ctx, remote)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list branches on %s: %w", remote, err)
+	}
+
+	var missing []string
+	for _, name := range branchNames {
+		if name == "" {
+			continue
+		}
+		if _, ok := remoteShas[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing, nil
+}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -77,6 +77,9 @@ type BranchStatus interface {
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)
 	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
+	// MissingRemoteBranches returns the subset of the given branches that no
+	// longer exist on the configured remote.
+	MissingRemoteBranches(ctx context.Context, branchNames []string) ([]string, error)
 	// TrunkRemoteState reports how the local trunk relates to its
 	// remote-tracking branch using only local refs (no network).
 	TrunkRemoteState(ctx context.Context) TrunkRemoteState
@@ -176,6 +179,11 @@ type BranchReader interface {
 // BranchTracking handles branch tracking operations
 type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
+	// TrackBranchPastLandedParent tracks a branch under a substitute parent
+	// when the parent it was built on is gone locally, using the recorded
+	// prior parent to anchor the divergence point so a later restack does not
+	// replay landed commits.
+	TrackBranchPastLandedParent(ctx context.Context, branchName string, parentBranchName string, prior PriorParent) error
 	// UntrackBranches stops tracking multiple branches, deleting their metadata
 	// and triggering a single engine rebuild.
 	UntrackBranches(ctx context.Context, branchNames []string) error

--- a/internal/integration/get_landed_parent_test.go
+++ b/internal/integration/get_landed_parent_test.go
@@ -1,0 +1,362 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	syncaction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// These tests model the state `st get` faces after a parent PR merges: GitHub
+// deletes the merged branch, but the child's pushed metadata still names it as
+// the parent. get's fetch asks for every ancestor head in one refspec list, and
+// git fails the whole fetch when one of them is gone — so the branch the user
+// asked for never arrives.
+//
+// Two things have to hold once the fetch survives that. The branch must be
+// tracked against an ancestor that still exists, and — because the landed
+// parent's commits are still in the fetched branch — a restack must replay only
+// the branch's own commits. The second is the multiplayer-safety invariant
+// (.claude/rules/multiplayer-safety.md, "Reparent Past Landed Work, Never
+// Replay It") and it fails for squash and rebase merges if the divergence point
+// is taken as a plain merge-base against the new parent.
+
+// landedParentHandler answers get's landed-ancestor prompt and records what it
+// was told, standing in for the interactive CLI handler.
+type landedParentHandler struct {
+	actions.GetNullHandler
+	decision actions.LandedAncestorDecision
+	reports  []actions.LandedAncestorReport
+}
+
+func (h *landedParentHandler) ReportLandedAncestors(report actions.LandedAncestorReport) (actions.LandedAncestorDecision, error) {
+	h.reports = append(h.reports, report)
+	return h.decision, nil
+}
+
+// mergeMethod lands branch a on trunk the way one of GitHub's merge buttons
+// would. Each leaves a different history, and only the merge commit keeps a's
+// original SHAs reachable from trunk.
+type mergeMethod func(t *testing.T, sh *scenario.Scenario)
+
+func mergeCommitLanding(t *testing.T, sh *scenario.Scenario) {
+	t.Helper()
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("merge", "--no-ff", "-m", "Merge pull request #1", "a"))
+}
+
+// squashLanding lands a's whole tree as one commit, the multi-commit squash
+// case: none of a's original commits are reachable from trunk and no single
+// commit on trunk patch-matches any of them.
+func squashLanding(t *testing.T, sh *scenario.Scenario) {
+	t.Helper()
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("checkout", "a", "--", "."))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("commit", "-m", "Squash a (#1)"))
+}
+
+// rebaseLanding replays a's commits onto trunk with fresh SHAs.
+func rebaseLanding(t *testing.T, sh *scenario.Scenario) {
+	t.Helper()
+	out, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main..a")
+	require.NoError(t, err)
+	for _, commit := range strings.Fields(out) {
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("cherry-pick", commit))
+	}
+}
+
+// forgottenMetadata names the remote stackit metadata refs a scenario deletes
+// alongside the landed branch, which decides how much of the ancestry `get` can
+// still reconstruct.
+type forgottenMetadata int
+
+const (
+	// keepAllMetadata leaves every metadata ref on the remote.
+	keepAllMetadata forgottenMetadata = iota
+	// forgetLandedMetadata deletes only the landed parent's metadata ref, which
+	// is what the author's own `stackit sync` does during branch cleanup. The
+	// ancestry crawl then abandons the chain and falls back to GitHub, but the
+	// child's own metadata still records the tip it was pushed on top of.
+	forgetLandedMetadata
+	// forgetAllMetadata deletes the child's metadata ref as well, the shape a
+	// collaborator who does not use stackit leaves behind. Nothing records the
+	// landed parent's tip, so nothing can safely rebase the child.
+	forgetAllMetadata
+)
+
+// stackWithLandedParent builds main -> a -> b, submits it so both branches and
+// their metadata are on the remote, lands a on trunk with the given merge
+// method, deletes a's branch from the remote, and forgets both branches
+// locally.
+func stackWithLandedParent(t *testing.T, land mergeMethod, forget forgottenMetadata) *scenario.Scenario {
+	t.Helper()
+
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// a has two commits so the squash case is the one that matters: a single
+	// commit would patch-match through `git cherry` and prove nothing.
+	sh.CreateBranch("a").
+		CommitChange("a1", "a one").
+		CommitChange("a2", "a two").
+		TrackBranch("a", "main")
+	// b touches a file of its own so a replay never conflicts — that isolates
+	// "did b inherit a's commits" from any conflict noise.
+	sh.CreateBranch("b").
+		CommitChange("b1", "b one").
+		TrackBranch("b", "a")
+
+	sh.Context.GitHubClient = newCountingGitHubClient(t, testhelpers.NewMockGitHubServerConfig())
+	require.NoError(t, submit.Action(sh.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{}))
+	require.NoError(t, syncaction.Action(sh.Context, syncaction.Options{}, nil))
+
+	sh.Checkout("main")
+	land(t, sh)
+	// Trunk moves on after the merge, as it always does in a shared repo. This
+	// is what makes replaying a's commits harmful rather than merely wasteful:
+	// applied on top of someone else's edit to the same file they conflict,
+	// where skipping them entirely rebases cleanly.
+	sh.CommitChange("a1", "a one, revised on trunk")
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", "main"))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", ":refs/heads/a"))
+	if forget >= forgetLandedMetadata {
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", ":refs/stackit/metadata/a"))
+	}
+	if forget >= forgetAllMetadata {
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", ":refs/stackit/metadata/b"))
+	}
+
+	// Forget both branches locally: this is a fresh clone's view, where get has
+	// to recreate b from the remote and has no local a to fall back on.
+	dropLocalBranch(t, sh, "b")
+	dropLocalBranch(t, sh, "a")
+	sh.Rebuild()
+
+	return sh
+}
+
+// restackBranchOntoStack restacks a single branch and its upstack, the same
+// work `st restack` does after an unfreeze.
+func restackBranchOntoStack(t *testing.T, sh *scenario.Scenario, branch string) {
+	t.Helper()
+	sh.Checkout(branch)
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: branch,
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+	sh.Rebuild()
+}
+
+// commitsInB counts the commits reachable from b but not from main. b owns
+// exactly one; anything more means it inherited a's landed commits.
+func commitsInB(t *testing.T, sh *scenario.Scenario) int {
+	t.Helper()
+	count, err := sh.Scene.Repo.GetCommitCount("main", "b")
+	require.NoError(t, err)
+	return count
+}
+
+func TestGetPastLandedParent(t *testing.T) {
+	t.Parallel()
+
+	// Every merge method must reach the same place: b fetched, tracked against
+	// main, and carrying only its own commit after the restack.
+	for _, tc := range []struct {
+		name string
+		land mergeMethod
+	}{
+		{"merge commit", mergeCommitLanding},
+		{"multi-commit squash", squashLanding},
+		{"rebase merge", rebaseLanding},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sh := stackWithLandedParent(t, tc.land, keepAllMetadata)
+
+			handler := &landedParentHandler{decision: actions.UnfreezeAndRestack}
+			require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+			sh.Rebuild()
+
+			sh.ExpectStackStructure(map[string]string{"b": "main"})
+			require.Equal(t, 1, commitsInB(t, sh),
+				"b must contain only its own commit, not the landed parent's")
+			require.False(t, sh.Engine.GetBranch("b").IsFrozen(),
+				"confirming the prompt should leave b editable")
+			requireCleanWorkingTree(t, sh)
+		})
+	}
+}
+
+func TestGetPastLandedParentReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("names the landed parent, its PR, and the branch left frozen", func(t *testing.T) {
+		t.Parallel()
+		sh := stackWithLandedParent(t, squashLanding, keepAllMetadata)
+
+		handler := &landedParentHandler{decision: actions.LeaveFrozen}
+		require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+
+		require.Len(t, handler.reports, 1)
+		report := handler.reports[0]
+		require.True(t, report.CanRestack)
+		require.Equal(t, []string{"b"}, report.Unfreezable(),
+			"get freezes new branches, so b is what stays stale")
+		require.Empty(t, report.Unanchored(),
+			"b's own remote metadata records the tip it was pushed on top of")
+		require.Len(t, report.Reanchored, 1)
+		require.Equal(t, "b", report.Reanchored[0].Branch)
+		require.Equal(t, "a", report.Reanchored[0].LandedParent)
+		require.Equal(t, "main", report.Reanchored[0].NewParent)
+		require.NotNil(t, report.Reanchored[0].LandedPR,
+			"a's PR number is in the metadata it was pushed with")
+	})
+
+	// Declining is get's contract, not a failure: the branch keeps mirroring
+	// the remote. It is still tracked against a parent that exists, so the
+	// stack renders, and the divergence point recorded for it is the landed
+	// tip — so a later unfreeze + restack still replays only b's commit.
+	t.Run("declining leaves the branch frozen and unrebased", func(t *testing.T) {
+		t.Parallel()
+		sh := stackWithLandedParent(t, squashLanding, keepAllMetadata)
+
+		handler := &landedParentHandler{decision: actions.LeaveFrozen}
+		require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+		sh.Rebuild()
+
+		sh.ExpectStackStructure(map[string]string{"b": "main"})
+		require.True(t, sh.Engine.GetBranch("b").IsFrozen())
+		require.Equal(t, 3, commitsInB(t, sh),
+			"a frozen branch still mirrors the remote, landed commits and all")
+
+		// The remedy get points at has to work.
+		require.NoError(t, actions.UnfreezeAction(sh.Context, "b"))
+		sh.Rebuild()
+		restackBranchOntoStack(t, sh, "b")
+		require.Equal(t, 1, commitsInB(t, sh))
+	})
+
+	// A parent that is gone from the remote but still checked out locally is a
+	// branch the user may still be working with. get leaves the relationship
+	// alone; restack's own landed-parent handling reparents past it.
+	t.Run("does not re-anchor past a parent that still exists locally", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewRemoteScenario(t)
+		disableCommitSigning(t, sh)
+
+		sh.CreateBranch("a").
+			CommitChange("a1", "a one").
+			CommitChange("a2", "a two").
+			TrackBranch("a", "main")
+		sh.CreateBranch("b").
+			CommitChange("b1", "b one").
+			TrackBranch("b", "a")
+
+		sh.Context.GitHubClient = newCountingGitHubClient(t, testhelpers.NewMockGitHubServerConfig())
+		require.NoError(t, submit.Action(sh.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{}))
+		require.NoError(t, syncaction.Action(sh.Context, syncaction.Options{}, nil))
+
+		sh.Checkout("main")
+		squashLanding(t, sh)
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", "main"))
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", ":refs/heads/a"))
+		sh.Rebuild()
+
+		handler := &landedParentHandler{decision: actions.UnfreezeAndRestack}
+		require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+		sh.Rebuild()
+
+		require.Empty(t, handler.reports, "a is still local, so nothing was re-anchored")
+		require.Equal(t, 1, commitsInB(t, sh),
+			"restack should reparent b past the landed local parent on its own")
+	})
+}
+
+// The ancestry crawl abandons the whole chain the moment one ancestor has no
+// metadata — and that is the state the author's own `stackit sync` leaves a
+// merged parent in, since branch cleanup deletes its remote metadata ref. get
+// then falls back to a GitHub crawl, which reads PR bases and knows no
+// revisions. Without harvesting the anchor from the child's own metadata, the
+// branch is re-anchored with nothing to anchor against and the restack replays
+// the landed commits.
+func TestGetPastLandedParentWithoutParentMetadata(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		land mergeMethod
+	}{
+		{"merge commit", mergeCommitLanding},
+		{"multi-commit squash", squashLanding},
+		{"rebase merge", rebaseLanding},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sh := stackWithLandedParent(t, tc.land, forgetLandedMetadata)
+
+			handler := &landedParentHandler{decision: actions.UnfreezeAndRestack}
+			require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+			sh.Rebuild()
+
+			require.Len(t, handler.reports, 1)
+			require.Empty(t, handler.reports[0].Unanchored(),
+				"b's own metadata survives and records the tip it was pushed on top of")
+			sh.ExpectStackStructure(map[string]string{"b": "main"})
+			require.Equal(t, 1, commitsInB(t, sh),
+				"b must contain only its own commit, not the landed parent's")
+			requireCleanWorkingTree(t, sh)
+		})
+	}
+}
+
+// With no stackit metadata anywhere on the remote there is nothing recording
+// the tip b was pushed on top of, so nothing can tell the landed commits apart
+// from b's own. Re-anchoring is still right — tracking b against a branch that
+// no longer exists would be worse — but rebasing is not, so get must report the
+// branch as unanchored and leave it frozen rather than offer a replay.
+func TestGetPastLandedParentWithNoMetadataAtAll(t *testing.T) {
+	t.Parallel()
+	sh := stackWithLandedParent(t, squashLanding, forgetAllMetadata)
+
+	handler := &landedParentHandler{decision: actions.UnfreezeAndRestack}
+	require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+	sh.Rebuild()
+
+	require.Len(t, handler.reports, 1)
+	report := handler.reports[0]
+	require.Equal(t, []string{"b"}, report.Unanchored(),
+		"nothing recorded a's tip, so b cannot be rebased safely")
+	require.Empty(t, report.Unfreezable(),
+		"an unanchored branch must never be offered for unfreeze")
+
+	sh.ExpectStackStructure(map[string]string{"b": "main"})
+	require.True(t, sh.Engine.GetBranch("b").IsFrozen(),
+		"b stays frozen even though the handler asked to unfreeze")
+	require.Equal(t, 3, commitsInB(t, sh),
+		"b goes on mirroring the remote rather than replaying the landed commits")
+	requireCleanWorkingTree(t, sh)
+}
+
+// --restack=false leaves nothing for an unfreeze to feed, so get must not act
+// on a handler that asks for one anyway.
+func TestGetPastLandedParentWithoutRestack(t *testing.T) {
+	t.Parallel()
+	sh := stackWithLandedParent(t, squashLanding, keepAllMetadata)
+
+	handler := &landedParentHandler{decision: actions.UnfreezeAndRestack}
+	require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: false}, handler))
+	sh.Rebuild()
+
+	require.Len(t, handler.reports, 1)
+	require.False(t, handler.reports[0].CanRestack)
+	require.True(t, sh.Engine.GetBranch("b").IsFrozen(),
+		"unfreezing without a restack would drop the protection and rebase nothing")
+}


### PR DESCRIPTION

get resolves a branch's ancestry from the metadata it was pushed with,
then asks for every ancestor head in one refspec list. Explicit refspecs
are all-or-nothing, so a parent that merged and had its branch deleted
on GitHub failed the whole fetch, and the branch the user asked for
never arrived.

Recover by listing the remote's refs, dropping the branches that are
gone, and fetching the rest. That listing only runs on the failure path,
so a healthy stack still fetches in one round trip. Children of a landed
parent are then tracked against the nearest ancestor that survives,
carrying the landed parent's recorded tip as their divergence anchor --
without it a plain merge-base against trunk puts the landed commits back
into a later restack's replay range for squash and rebase merges.

Re-anchoring moves the parent pointer, not the commits, and get checks
branches out frozen, which restack never rebases. So it is reported
rather than done silently: get names the landed branch and offers to
unfreeze and restack there and then. Declining leaves the branch
mirroring the remote, which is get's contract.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AdXAxaCaNxc4S4ApGcCNdX