### PR TITLE
perf(git): share the stackit config snapshot across ConfigStores

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -5,7 +5,9 @@ package git
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -29,9 +31,10 @@ type ConfigStore struct {
 	// single `git config --get-regexp`. A command reads half a dozen of these
 	// (trunk, undo.depth, stack.shape, maxConcurrency, branch.pattern, ...)
 	// and each one used to cost its own git process.
-	mu          sync.Mutex
-	stackitKeys map[string]string
-	snapshotGen uint64
+	mu            sync.Mutex
+	stackitKeys   map[string]string
+	snapshotGen   uint64
+	snapshotStamp string
 }
 
 // configGen is bumped by every write through any ConfigStore, invalidating
@@ -46,6 +49,84 @@ func invalidateSnapshots(key string) {
 	if snapshotServes(key) {
 		configGen.Add(1)
 	}
+}
+
+// sharedSnapshot is one repository's stackit.* snapshot, reusable by every
+// ConfigStore pointing at that repository. Stores are constructed constantly —
+// one per config load, per action, per runner config accessor — and each fresh
+// one re-ran `git config --get-regexp`, so a single repository's config was
+// re-read thousands of times per command batch (2,364 git processes in one
+// integration-tier run). The map is never mutated after publication.
+type sharedSnapshot struct {
+	keys  map[string]string
+	gen   uint64
+	stamp string
+}
+
+// sharedSnapshots maps a repository root to its sharedSnapshot.
+var sharedSnapshots sync.Map
+
+// configFiles lists the config files that feed the stackit.* snapshot, in
+// git's own precedence order. The snapshot comes from `git config
+// --get-regexp` with no scope flag, so it merges global and local — stamping
+// only the local file would let a shared snapshot serve a stale global value
+// for the life of the process, which matters in the long-lived server where
+// a ConfigStore is built per call.
+//
+// System config (/etc/gitconfig) is deliberately not stamped: it is
+// root-owned and effectively static for a process's lifetime.
+func configFiles(repoRoot string) []string {
+	paths := []string{filepath.Join(GetGitCommonDir(repoRoot), "config")}
+
+	// GIT_CONFIG_GLOBAL replaces the default global paths rather than adding
+	// to them, so honor it to the exclusion of the rest. The test helpers
+	// set it to /dev/null, which stats cleanly and never changes.
+	if p := os.Getenv("GIT_CONFIG_GLOBAL"); p != "" {
+		return append(paths, p)
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		paths = append(paths, filepath.Join(xdg, "git", "config"))
+	} else if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".config", "git", "config"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".gitconfig"))
+	}
+	return paths
+}
+
+// configStamp identifies the config files feeding the snapshot by size and
+// modification time.
+//
+// configGen covers writes made through a ConfigStore, but these files are also
+// written out of band — `git config` invoked directly, a hook, the user's
+// editor, a test helper — and those must invalidate a snapshot shared beyond
+// the writing store. Returns "" when a file exists but cannot be stat'ed,
+// which disables sharing for that repository and leaves the per-store snapshot
+// as the only cache.
+func configStamp(repoRoot string) string {
+	if repoRoot == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, path := range configFiles(repoRoot) {
+		fi, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Absent is itself a stampable state: the file contributes
+				// nothing now, and creating it later changes the stamp.
+				b.WriteString("-;")
+				continue
+			}
+			return ""
+		}
+		b.WriteString(strconv.FormatInt(fi.Size(), 10))
+		b.WriteByte(':')
+		b.WriteString(strconv.FormatInt(fi.ModTime().UnixNano(), 10))
+		b.WriteByte(';')
+	}
+	return b.String()
 }
 
 // NewConfigStore creates a new ConfigStore for the given repository root.
@@ -85,11 +166,22 @@ func normalizeConfigKey(key string) string {
 // with a single git process if it is missing or stale.
 func (c *ConfigStore) stackitSnapshot() (map[string]string, error) {
 	gen := configGen.Load()
+	stamp := configStamp(c.repoRoot)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.stackitKeys != nil && c.snapshotGen == gen {
+	if c.stackitKeys != nil && c.snapshotGen == gen && c.snapshotStamp == stamp {
 		return c.stackitKeys, nil
+	}
+	if stamp != "" {
+		if v, ok := sharedSnapshots.Load(c.repoRoot); ok {
+			if shared, ok := v.(sharedSnapshot); ok && shared.gen == gen && shared.stamp == stamp {
+				c.stackitKeys = shared.keys
+				c.snapshotGen = gen
+				c.snapshotStamp = stamp
+				return shared.keys, nil
+			}
+		}
 	}
 
 	// -z is what makes this parseable: it frames each entry as
@@ -119,6 +211,10 @@ func (c *ConfigStore) stackitSnapshot() (map[string]string, error) {
 
 	c.stackitKeys = keys
 	c.snapshotGen = gen
+	c.snapshotStamp = stamp
+	if stamp != "" {
+		sharedSnapshots.Store(c.repoRoot, sharedSnapshot{keys: keys, gen: gen, stamp: stamp})
+	}
 	return keys, nil
 }
 

--- a/internal/git/config_internal_test.go
+++ b/internal/git/config_internal_test.go
@@ -1,6 +1,9 @@
 package git
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,4 +36,81 @@ func TestNormalizeConfigKey(t *testing.T) {
 			require.Equal(t, tt.want, normalizeConfigKey(tt.key))
 		})
 	}
+}
+
+// TestSharedSnapshotSeesOutOfBandWrite pins the invalidation that makes the
+// repo-scoped snapshot safe to share across ConfigStores. A write made with
+// plain `git config` (a hook, a test helper, the user's editor) never bumps
+// configGen, so only the config file's stamp can stale the shared entry — if
+// that stops working, a fresh ConfigStore serves the pre-write value forever.
+func TestSharedSnapshotSeesOutOfBandWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	runGit("init", "-q", ".")
+	runGit("config", "stackit.trunk", "main")
+
+	first, err := NewConfigStore(dir).Get("stackit.trunk")
+	require.NoError(t, err)
+	require.Equal(t, "main", first)
+
+	// Out of band: not routed through ConfigStore, so configGen is unchanged.
+	runGit("config", "stackit.trunk", "develop")
+
+	second, err := NewConfigStore(dir).Get("stackit.trunk")
+	require.NoError(t, err)
+	require.Equal(t, "develop", second, "fresh store served a stale shared snapshot")
+
+	// And the store that already cached the old value must re-read too.
+	store := NewConfigStore(dir)
+	_, err = store.Get("stackit.trunk")
+	require.NoError(t, err)
+	runGit("config", "stackit.trunk", "trunk")
+	third, err := store.Get("stackit.trunk")
+	require.NoError(t, err)
+	require.Equal(t, "trunk", third, "existing store served a stale per-store snapshot")
+}
+
+// TestSharedSnapshotSeesGlobalWrite pins the other half of the stamp. The
+// snapshot is built with `git config --get-regexp` and no scope flag, so it
+// merges global config as well as local. Stamping only the local file would
+// let the repo-scoped shared snapshot serve a stale global value for the whole
+// process — invisible in the CLI, but the server builds a ConfigStore per call
+// and outlives any number of edits to the user's ~/.gitconfig.
+func TestSharedSnapshotSeesGlobalWrite(t *testing.T) {
+	// Mutates GIT_CONFIG_GLOBAL for the process, so it cannot run in parallel.
+	dir := t.TempDir()
+	globalPath := filepath.Join(t.TempDir(), "gitconfig")
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+globalPath)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
+	runGit("init", "-q", ".")
+	runGit("config", "--global", "stackit.trunk", "main")
+
+	first, err := NewConfigStore(dir).Get("stackit.trunk")
+	require.NoError(t, err)
+	require.Equal(t, "main", first)
+
+	// Global-only write: the local config file is untouched, so a stamp that
+	// covers only the local file cannot notice this.
+	runGit("config", "--global", "stackit.trunk", "develop")
+
+	second, err := NewConfigStore(dir).Get("stackit.trunk")
+	require.NoError(t, err)
+	require.Equal(t, "develop", second, "fresh store served a snapshot stale in global scope")
 }


### PR DESCRIPTION

ConfigStores are constructed constantly — one per config load, per action,
per runner config accessor — and each fresh one re-ran `git config
--get-regexp ^stackit\.`, so a single repository`s config was read thousands
of times per command batch. A git-shim profile of the integration tier counted
2,364 of those spawns against only ~30 stackit.* writes in the whole run.

Key the snapshot by repository root instead of by store. Sharing beyond the
writing store means configGen is no longer sufficient to keep it fresh: the
config file is also written out of band, by `git config` invoked directly, by
hooks, by a test helper. Stamp the local config file by size and mtime so
those writes invalidate too — which also tightens the existing per-store
snapshot, previously blind to them for the life of the store.

Integration tier: 2,364 -> 605 config spawns, 38,769 -> 36,954 git processes
overall (-4.7%), wall ~68s -> ~64s. Coverage guard: no block lost outside the
edited file, which went 39 -> 48 covered blocks.