### PR TITLE
refactor(tui): use core key constants instead of raw string literals

### DIFF
--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -16,6 +16,7 @@ import (
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/core"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -343,7 +344,7 @@ func (m *logPagerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyPressMsg:
 		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		case core.KeyQuit, core.KeyEsc, core.KeyCtrlC:
 			return m, tea.Quit
 		case "g", "home":
 			m.viewport.GotoTop()

--- a/internal/tui/components/tree/tree_model.go
+++ b/internal/tui/components/tree/tree_model.go
@@ -5,6 +5,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // Model wraps StackTreeRenderer to make it a tea.Model for the storyboard
@@ -42,7 +44,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Options.Mode = RenderModeFull
 			}
 			return m, nil
-		case "q", "ctrl+c", "esc":
+		case core.KeyQuit, core.KeyCtrlC, core.KeyEsc:
 			return m, tea.Quit
 		}
 	case tea.WindowSizeMsg:

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -332,11 +332,11 @@ func (m promptListModel) Init() tea.Cmd {
 func (m promptListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
-		if msg.String() == "ctrl+c" {
+		if msg.String() == KeyCtrlC {
 			m.err = errors.ErrCanceled
 			return m, tea.Quit
 		}
-		if msg.String() == "enter" {
+		if msg.String() == KeyEnter {
 			if i, ok := m.list.SelectedItem().(listItem); ok {
 				m.selected = i.value
 				return m, tea.Quit

--- a/internal/tui/stories.go
+++ b/internal/tui/stories.go
@@ -470,7 +470,7 @@ func (m *submitSimulationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 
 	case tea.KeyPressMsg:
-		if msg.String() == "q" || msg.String() == "esc" || msg.String() == "ctrl+c" {
+		if msg.String() == KeyQuit || msg.String() == KeyEsc || msg.String() == KeyCtrlC {
 			return m, tea.Quit
 		}
 	}


### PR DESCRIPTION
## Summary

- Several `tea.KeyPressMsg` handlers compared `msg.String()` against raw string literals (`"ctrl+c"`, `"esc"`, `"q"`, `"enter"`) instead of the `core.Key*` constants (or their package-level aliases in `internal/tui`) that already exist for exactly this purpose.
- Replaced the literals with the existing constants in `internal/tui/prompts.go`, `internal/tui/stories.go`, `internal/tui/components/tree/tree_model.go`, and `internal/cli/navigation/log.go` — every spot in the codebase with this pattern.
- No behavior change: the constants hold the same string values as the literals they replace.

This follows the existing project convention (`.claude/rules/code-style.md`): "Never use string literals like `\"ctrl+c\"`" for key comparisons; use the constants in `internal/tui/core`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/tui/... ./internal/cli/navigation/...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./internal/tui/... ./internal/cli/navigation/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZGZMqo14UhjY5rnQkLRJq

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZGZMqo14UhjY5rnQkLRJq)_