### PR TITLE
fix(git): stop truncating multi-line values in GetAll

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -169,7 +169,11 @@ func (c *ConfigStore) Get(key string) (string, error) {
 // GetAll retrieves all values for a multi-value config key.
 // Returns empty slice if the key doesn't exist.
 func (c *ConfigStore) GetAll(key string) ([]string, error) {
-	out, err := c.runGitConfig("--get-all", key)
+	// -z NUL-terminates each value instead of newline-separating them, so a
+	// value containing an embedded newline (a multi-line approved hook
+	// command, say) stays one entry instead of splitting into extras that
+	// never match the original value again.
+	out, err := c.runGitConfig("-z", "--get-all", key)
 	if err != nil {
 		if isExitCode(err, 1) {
 			return nil, nil
@@ -179,8 +183,11 @@ func (c *ConfigStore) GetAll(key string) ([]string, error) {
 	if out == "" {
 		return nil, nil
 	}
-	values := strings.Split(out, "\n")
-	return values, nil
+	// -z terminates every value, leaving one trailing empty element after
+	// Split; drop it rather than filtering all empties, which would also
+	// discard a legitimate empty-string value.
+	values := strings.Split(out, "\x00")
+	return values[:len(values)-1], nil
 }
 
 // Set sets a config value in local git config.

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -255,6 +255,30 @@ func TestConfigStore_MultiValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, vals)
 	})
+
+	t.Run("round-trips a value containing newlines without splitting it", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+		store := git.NewConfigStore(scene.Dir)
+
+		// stackit.hooks.approved.* stores free-form approved hook commands.
+		// A multi-line command split into fragments here would never match
+		// the original string again, so approval would never stick.
+		multiline := "make lint\nmake test"
+		err := store.Add("stackit.test.list", "first")
+		require.NoError(t, err)
+
+		err = store.Add("stackit.test.list", multiline)
+		require.NoError(t, err)
+
+		err = store.Add("stackit.test.list", "third")
+		require.NoError(t, err)
+
+		vals, err := store.GetAll("stackit.test.list")
+		require.NoError(t, err)
+		require.Equal(t, []string{"first", multiline, "third"}, vals)
+	})
 }
 
 func TestConfigStore_Unset(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ConfigStore.GetAll` read multi-value git config keys with `git config --get-all <key>` and split the output on `"\n"`. A single value containing an embedded newline (e.g. a multi-line `stackit.hooks.approved.*` command) is indistinguishable from a value boundary once newline-joined, so it silently splits into extra fragments.
- Those fragments never equal the original string again, so e.g. `IsHookApproved` never matches a previously-approved multi-line hook command — it keeps re-prompting for approval, and each approval accumulates a new (still-fragmented) duplicate entry in git config.
- This is the same bug class already fixed for `stackitSnapshot()` in a prior commit (`b394dca`, "stop truncating multi-line stackit config values"), just not applied to `GetAll`. This PR mirrors that fix: read with `git config -z --get-all`, which NUL-terminates each value instead of newline-separating them, and split on `\x00` (dropping the single trailing empty element `-z` produces, rather than filtering all empty strings, so a legitimate empty-string value is preserved).

## Test plan

- [x] Added a test reproducing the bug: a multi-value key where one value contains an embedded newline now round-trips intact through `Add`/`GetAll`.
- [x] `go test ./internal/git/...` passes.
- [x] `go test ./internal/config/...` passes (covers `GetAll` consumers: approved hooks, trunks, submit labels/reviewers/assignees).
- [x] `go build ./...` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UUaVR2dexsxvbsCE6EZsM

---
_Generated by [Claude Code](https://claude.ai/code/session_012UUaVR2dexsxvbsCE6EZsM)_