### PR TITLE
perf: reduce test waits and redundant CLI work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,9 @@ jobs:
         run: |
           PACKAGES="$(bash scripts/go-test-packages.sh all)"
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            go test -v -race -p=1 -parallel=2 -coverprofile=coverage.out $PACKAGES
+            bash scripts/with-test-binary.sh go test -v -race -p=1 -parallel=2 -coverprofile=coverage.out $PACKAGES
           else
-            go test -v -coverprofile=coverage.out $PACKAGES
+            bash scripts/with-test-binary.sh go test -v -coverprofile=coverage.out $PACKAGES
           fi
 
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,24 @@ Stackit has several kinds of Go tests. Keep the tier explicit so local checks st
 
 Package selection is centralized in `scripts/go-test-packages.sh`. Update that script when adding or reclassifying package-level tiers.
 
+## Shared CLI binary
+
+The all, git, and integration runners build the CLI once with
+`scripts/with-test-binary.sh` and pass its path through `STACKIT_TEST_BINARY`.
+The binary lives at a content-addressed path in the Go build cache, so unchanged
+runs retain Go's test-result caching and concurrent revisions use separate files.
+Fast and unit tiers do not pay for this build.
+
+Direct `go test` and `test:pkg` invocations still build lazily per package when
+they need a subprocess. To share a binary for a custom multi-package run:
+
+```bash
+bash scripts/with-test-binary.sh go test ./internal/cli/...
+```
+
+An explicitly supplied `STACKIT_TEST_BINARY` must be an absolute path to an
+executable file. Test packages validate it and never delete a caller-owned binary.
+
 ## Organizing New Tests
 
 Prefer the cheapest test shape that proves the behavior:

--- a/internal/actions/merge/ci_waiter_test.go
+++ b/internal/actions/merge/ci_waiter_test.go
@@ -3,6 +3,7 @@ package merge
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -24,72 +25,75 @@ func TestWaitForChecks(t *testing.T) {
 
 	t.Run("returns immediately when no checks expected", func(t *testing.T) {
 		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			waiter := NewCIWaiter(CIWaiterOptions{
+				Client:       &mockGitHubClient{},
+				Timeout:      5 * time.Second,
+				PollInterval: 100 * time.Millisecond,
+			})
 
-		waiter := NewCIWaiter(CIWaiterOptions{
-			Client:       &mockGitHubClient{},
-			Timeout:      5 * time.Second,
-			PollInterval: 100 * time.Millisecond,
+			start := time.Now()
+			result, err := waiter.WaitForChecks(context.Background(), "branch", 1, false)
+			elapsed := time.Since(start)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.True(t, result.Passed)
+			// Should return almost immediately, not wait for any polling
+			require.Less(t, elapsed, 1*time.Second)
 		})
-
-		start := time.Now()
-		result, err := waiter.WaitForChecks(context.Background(), "branch", 1, false)
-		elapsed := time.Since(start)
-
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.True(t, result.Passed)
-		// Should return almost immediately, not wait for any polling
-		require.Less(t, elapsed, 1*time.Second)
 	})
 
 	t.Run("returns when checks pass", func(t *testing.T) {
 		t.Parallel()
-
-		client := &mockGitHubClient{
-			checkStatus: &github.CheckStatus{
-				Passing: true,
-				Pending: false,
-				Checks: []github.CheckDetail{
-					{Name: "ci", Status: "COMPLETED", Conclusion: "SUCCESS"},
+		synctest.Test(t, func(t *testing.T) {
+			client := &mockGitHubClient{
+				checkStatus: &github.CheckStatus{
+					Passing: true,
+					Pending: false,
+					Checks: []github.CheckDetail{
+						{Name: "ci", Status: "COMPLETED", Conclusion: "SUCCESS"},
+					},
 				},
-			},
-		}
+			}
 
-		waiter := NewCIWaiter(CIWaiterOptions{
-			Client:       client,
-			Timeout:      30 * time.Second, // Enough to cover CIRegistrationDelay + poll
-			PollInterval: 100 * time.Millisecond,
+			waiter := NewCIWaiter(CIWaiterOptions{
+				Client:       client,
+				Timeout:      30 * time.Second, // Enough to cover CIRegistrationDelay + poll
+				PollInterval: 100 * time.Millisecond,
+			})
+
+			result, err := waiter.WaitForChecks(context.Background(), "branch", 1, true)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.True(t, result.Passed)
 		})
-
-		result, err := waiter.WaitForChecks(context.Background(), "branch", 1, true)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.True(t, result.Passed)
 	})
 
 	t.Run("returns error when checks fail", func(t *testing.T) {
 		t.Parallel()
-
-		client := &mockGitHubClient{
-			checkStatus: &github.CheckStatus{
-				Passing: false,
-				Pending: false,
-				Checks: []github.CheckDetail{
-					{Name: "ci", Status: "COMPLETED", Conclusion: "FAILURE"},
+		synctest.Test(t, func(t *testing.T) {
+			client := &mockGitHubClient{
+				checkStatus: &github.CheckStatus{
+					Passing: false,
+					Pending: false,
+					Checks: []github.CheckDetail{
+						{Name: "ci", Status: "COMPLETED", Conclusion: "FAILURE"},
+					},
 				},
-			},
-		}
+			}
 
-		waiter := NewCIWaiter(CIWaiterOptions{
-			Client:       client,
-			Timeout:      30 * time.Second,
-			PollInterval: 100 * time.Millisecond,
+			waiter := NewCIWaiter(CIWaiterOptions{
+				Client:       client,
+				Timeout:      30 * time.Second,
+				PollInterval: 100 * time.Millisecond,
+			})
+
+			result, err := waiter.WaitForChecks(context.Background(), "branch", 1, true)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "CI checks failed")
+			require.NotNil(t, result)
+			require.False(t, result.Passed)
 		})
-
-		result, err := waiter.WaitForChecks(context.Background(), "branch", 1, true)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "CI checks failed")
-		require.NotNil(t, result)
-		require.False(t, result.Passed)
 	})
 }

--- a/internal/cli/branch/create_test.go
+++ b/internal/cli/branch/create_test.go
@@ -1,7 +1,6 @@
 package branch_test
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,29 +10,17 @@ import (
 
 func TestCreateCommand(t *testing.T) {
 	t.Parallel()
-	// Build the stackit binary first
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("create empty branch", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a new branch with no changes
-		cmd = exec.Command(binaryPath, "create", "feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature")
 
 		require.NoError(t, err, "create command failed: %s", string(output))
 		require.Contains(t, string(output), "No staged changes")
@@ -49,9 +36,7 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create unstaged changes
@@ -59,9 +44,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch with --all flag
-		cmd = exec.Command(binaryPath, "create", "feature", "--all", "-m", "Add feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature", "--all", "-m", "Add feature")
 
 		require.NoError(t, err, "create command failed: %s", string(output))
 
@@ -81,9 +64,7 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -91,9 +72,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch from commit message (no branch name provided)
-		cmd = exec.Command(binaryPath, "create", "-m", "Add new feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "-m", "Add new feature")
 
 		require.NoError(t, err, "create command failed: %s", string(output))
 
@@ -115,9 +94,7 @@ func TestCreateCommand(t *testing.T) {
 		})
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Modify tracked file (unstaged)
@@ -125,9 +102,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch with --update flag
-		cmd = exec.Command(binaryPath, "create", "feature", "--update", "-m", "Update file")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature", "--update", "-m", "Update file")
 
 		require.NoError(t, err, "create command failed: %s", string(output))
 
@@ -142,9 +117,7 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Detach HEAD
@@ -152,9 +125,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to create a branch (should fail)
-		cmd = exec.Command(binaryPath, "create", "feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature")
 
 		require.Error(t, err, "create should fail when not on a branch")
 		require.Contains(t, string(output), "not on a branch")
@@ -165,9 +136,7 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create branch manually
@@ -177,9 +146,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to create the same branch (should fail)
-		cmd = exec.Command(binaryPath, "create", "feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature")
 
 		require.Error(t, err, "create should fail when branch exists")
 		require.Contains(t, string(output), "already exists")
@@ -190,15 +157,11 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Try to create a branch without name or message
-		cmd = exec.Command(binaryPath, "create")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create")
 
 		require.Error(t, err, "create should fail without name or message")
 		require.Contains(t, string(output), "must specify either a branch name or commit message")
@@ -215,9 +178,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch (should auto-initialize)
-		cmd := exec.Command(binaryPath, "create", "feature", "-m", "Add feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature", "-m", "Add feature")
 
 		require.NoError(t, err, "create with auto-init failed: %s", string(output))
 		// Note: The auto-init message may or may not appear in combined output depending
@@ -231,9 +192,7 @@ func TestCreateCommand(t *testing.T) {
 
 		// Verify stackit is now initialized by running a command that requires init
 		// The tree command would fail if not initialized, so success here proves auto-init worked
-		cmd = exec.Command(binaryPath, "tree", "--stack")
-		cmd.Dir = scene.Dir
-		output, err = cmd.CombinedOutput()
+		output, err = runCLI(scene.Dir, "tree", "--stack")
 		require.NoError(t, err, "tree command failed after auto-init: %s", string(output))
 		require.Contains(t, string(output), "feature")
 	})
@@ -243,15 +202,11 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Set branch name pattern to just {message} for deterministic testing
-		cmd = exec.Command(binaryPath, "config", "set", "branch.pattern", "{message}")
-		cmd.Dir = scene.Dir
-		_, err = cmd.CombinedOutput()
+		_, err = runCLI(scene.Dir, "config", "set", "branch.pattern", "{message}")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -259,9 +214,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch from commit message
-		cmd = exec.Command(binaryPath, "create", "-m", "Add new feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "-m", "Add new feature")
 
 		require.NoError(t, err, "create command failed: %s", string(output))
 
@@ -276,9 +229,7 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -286,9 +237,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch from commit message (should use default pattern)
-		cmd = exec.Command(binaryPath, "create", "-m", "Add new feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "-m", "Add new feature")
 
 		require.NoError(t, err, "create command failed: %s", string(output))
 
@@ -308,21 +257,15 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Set a custom pattern
-		cmd = exec.Command(binaryPath, "config", "set", "branch.pattern", "{username}/{date}/{message}")
-		cmd.Dir = scene.Dir
-		_, err = cmd.CombinedOutput()
+		_, err = runCLI(scene.Dir, "config", "set", "branch.pattern", "{username}/{date}/{message}")
 		require.NoError(t, err)
 
 		// Get the pattern back
-		cmd = exec.Command(binaryPath, "config", "get", "branch.pattern")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "config", "get", "branch.pattern")
 		require.NoError(t, err)
 		require.Equal(t, "{username}/{date}/{message}\n", string(output))
 	})
@@ -332,15 +275,11 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Try to set a pattern without {message} (should fail)
-		cmd = exec.Command(binaryPath, "config", "set", "branch.pattern", "{username}/{date}")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "config", "set", "branch.pattern", "{username}/{date}")
 		require.Error(t, err, "config set should fail without {message} placeholder")
 		require.Contains(t, string(output), "must contain {message}")
 	})
@@ -350,15 +289,11 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a new branch with branch name (no message needed)
-		cmd = exec.Command(binaryPath, "create", "feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature")
 
 		require.NoError(t, err, "create with branch name should work")
 		require.Contains(t, string(output), "No staged changes")
@@ -374,9 +309,7 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -384,9 +317,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch with scope
-		cmd = exec.Command(binaryPath, "create", "feature", "--scope", "PROJ-123", "-m", "Add feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature", "--scope", "PROJ-123", "-m", "Add feature")
 
 		require.NoError(t, err, "create with scope failed: %s", string(output))
 
@@ -396,9 +327,7 @@ func TestCreateCommand(t *testing.T) {
 		require.Equal(t, "feature", currentBranch)
 
 		// Verify scope was set
-		cmd = exec.Command(binaryPath, "scope", "--show")
-		cmd.Dir = scene.Dir
-		output, err = cmd.CombinedOutput()
+		output, err = runCLI(scene.Dir, "scope", "--show")
 		require.NoError(t, err, "scope show failed: %s", string(output))
 		require.Contains(t, string(output), "PROJ-123")
 	})
@@ -408,17 +337,13 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a parent branch with scope
 		err = scene.Repo.CreateChange("parent content", "test", false)
 		require.NoError(t, err)
-		cmd = exec.Command(binaryPath, "create", "parent", "--scope", "PROJ-456", "-m", "Add parent")
-		cmd.Dir = scene.Dir
-		_, err = cmd.CombinedOutput()
+		_, err = runCLI(scene.Dir, "create", "parent", "--scope", "PROJ-456", "-m", "Add parent")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -426,9 +351,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch without explicit scope (should inherit from parent)
-		cmd = exec.Command(binaryPath, "create", "feature", "-m", "Add feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature", "-m", "Add feature")
 
 		require.NoError(t, err, "create without scope failed: %s", string(output))
 
@@ -438,9 +361,7 @@ func TestCreateCommand(t *testing.T) {
 		require.Equal(t, "feature", currentBranch)
 
 		// Verify scope was inherited
-		cmd = exec.Command(binaryPath, "scope", "--show")
-		cmd.Dir = scene.Dir
-		output, err = cmd.CombinedOutput()
+		output, err = runCLI(scene.Dir, "scope", "--show")
 		require.NoError(t, err, "scope show failed: %s", string(output))
 		require.Contains(t, string(output), "PROJ-456")
 		require.Contains(t, string(output), "inherits scope")
@@ -451,17 +372,13 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Create a parent branch with scope
 		err = scene.Repo.CreateChange("parent content", "test", false)
 		require.NoError(t, err)
-		cmd = exec.Command(binaryPath, "create", "parent", "--scope", "PROJ-789", "-m", "Add parent")
-		cmd.Dir = scene.Dir
-		_, err = cmd.CombinedOutput()
+		_, err = runCLI(scene.Dir, "create", "parent", "--scope", "PROJ-789", "-m", "Add parent")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -469,9 +386,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch with different scope (should override inheritance)
-		cmd = exec.Command(binaryPath, "create", "feature", "--scope", "PROJ-999", "-m", "Add feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "feature", "--scope", "PROJ-999", "-m", "Add feature")
 
 		require.NoError(t, err, "create with scope override failed: %s", string(output))
 
@@ -481,9 +396,7 @@ func TestCreateCommand(t *testing.T) {
 		require.Equal(t, "feature", currentBranch)
 
 		// Verify explicit scope was set (not inherited)
-		cmd = exec.Command(binaryPath, "scope", "--show")
-		cmd.Dir = scene.Dir
-		output, err = cmd.CombinedOutput()
+		output, err = runCLI(scene.Dir, "scope", "--show")
 		require.NoError(t, err, "scope show failed: %s", string(output))
 		require.Contains(t, string(output), "PROJ-999")
 		require.Contains(t, string(output), "explicit scope")
@@ -494,15 +407,11 @@ func TestCreateCommand(t *testing.T) {
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
 
 		// Initialize stackit
-		cmd := exec.Command(binaryPath, "init")
-		cmd.Dir = scene.Dir
-		_, err := cmd.CombinedOutput()
+		_, err := runCLI(scene.Dir, "init")
 		require.NoError(t, err)
 
 		// Set branch pattern to include scope
-		cmd = exec.Command(binaryPath, "config", "set", "branch.pattern", "{scope}/{message}")
-		cmd.Dir = scene.Dir
-		_, err = cmd.CombinedOutput()
+		_, err = runCLI(scene.Dir, "config", "set", "branch.pattern", "{scope}/{message}")
 		require.NoError(t, err)
 
 		// Create a change and stage it
@@ -510,9 +419,7 @@ func TestCreateCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a new branch with scope (name should include scope)
-		cmd = exec.Command(binaryPath, "create", "--scope", "PROJ-111", "-m", "Add feature")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCLI(scene.Dir, "create", "--scope", "PROJ-111", "-m", "Add feature")
 
 		require.NoError(t, err, "create with scope in pattern failed: %s", string(output))
 

--- a/internal/cli/branch/test_helpers_test.go
+++ b/internal/cli/branch/test_helpers_test.go
@@ -1,0 +1,8 @@
+package branch_test
+
+import "github.com/getstackit/stackit/testhelpers/inprocess"
+
+func runCLI(dir string, args ...string) ([]byte, error) {
+	result := inprocess.NewInProcessCLI().Run(dir, args...)
+	return []byte(result.Output), result.Err
+}

--- a/internal/cli/navigation/checkout_test.go
+++ b/internal/cli/navigation/checkout_test.go
@@ -11,17 +11,10 @@ import (
 
 func TestCheckoutCommand(t *testing.T) {
 	t.Parallel()
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("successful navigation", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create a stack: main -> a -> b
 		s.RunCli("create", "a", "-m", "a").
@@ -60,7 +53,7 @@ func TestCheckoutCommand(t *testing.T) {
 
 	t.Run("failure and interactive flags", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// 1. Invalid branch
 		output, err := s.RunCliAndGetOutput("checkout", "nonexistent")

--- a/internal/cli/navigation/cli_test_main_test.go
+++ b/internal/cli/navigation/cli_test_main_test.go
@@ -1,0 +1,13 @@
+package navigation_test
+
+import (
+	"github.com/getstackit/stackit/testhelpers/inprocess"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func init() {
+	scenario.SetGlobalInProcessRunner(func(workDir string, args ...string) (string, error) {
+		result := inprocess.NewInProcessCLI().Run(workDir, args...)
+		return result.Output, result.Err
+	})
+}

--- a/internal/cli/navigation/navigation_test.go
+++ b/internal/cli/navigation/navigation_test.go
@@ -12,17 +12,10 @@ import (
 
 func TestNavigationCommands(t *testing.T) {
 	t.Parallel()
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("linear stack navigation", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create stack: main -> a -> b -> c
 		s.RunCli("create", "a", "-m", "a").
@@ -88,7 +81,7 @@ func TestNavigationCommands(t *testing.T) {
 
 	t.Run("quiet down and bottom navigate correctly under light load path", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create stack: main -> a -> b -> c
 		s.RunCli("create", "a", "-m", "a").
@@ -111,7 +104,7 @@ func TestNavigationCommands(t *testing.T) {
 
 	t.Run("trunk and first branch navigation", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		s.RunCli("init")
 
@@ -172,7 +165,7 @@ func TestNavigationCommands(t *testing.T) {
 
 	t.Run("forked stack navigation", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create branches:
 		// main -> a -> b
@@ -224,7 +217,7 @@ func TestNavigationCommands(t *testing.T) {
 
 	t.Run("edge cases and error handling", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create stack: main -> a -> b
 		s.RunCli("create", "a", "-m", "a").
@@ -253,7 +246,7 @@ func TestNavigationCommands(t *testing.T) {
 
 	t.Run("trunk management", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		s.RunCli("init")
 
@@ -284,7 +277,7 @@ func TestNavigationCommands(t *testing.T) {
 	// not real subcommands.
 	t.Run("restack suggestion references real commands when branch falls behind", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create stack: main -> a -> b
 		s.RunCli("create", "a", "-m", "a").

--- a/internal/cli/navigation/tree_test.go
+++ b/internal/cli/navigation/tree_test.go
@@ -11,18 +11,10 @@ import (
 
 func TestLogCommand(t *testing.T) {
 	t.Parallel()
-	// Build the stackit binary first
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("tree in empty repo", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Run tree command
 		output, err := s.RunCliAndGetOutput("tree")
@@ -34,7 +26,7 @@ func TestLogCommand(t *testing.T) {
 
 	t.Run("tree with branches", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create a branch
 		s.CreateBranch("feature").
@@ -53,7 +45,7 @@ func TestLogCommand(t *testing.T) {
 
 	t.Run("tree with --stack flag", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create and checkout a branch
 		s.CreateBranch("feature")
@@ -67,7 +59,7 @@ func TestLogCommand(t *testing.T) {
 
 	t.Run("t aliases tree short", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 		s.CreateBranch("feature")
 
 		shortOutput, err := s.RunCliAndGetOutput("tree", "short")
@@ -82,7 +74,7 @@ func TestLogCommand(t *testing.T) {
 
 	t.Run("tree shows worktree indicator for stack with worktree", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 		s.WithInitialCommit()
 
 		// Create a staged change for the branch

--- a/internal/cli/stack/move_test.go
+++ b/internal/cli/stack/move_test.go
@@ -1,7 +1,6 @@
 package stack_test
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,13 +10,6 @@ import (
 
 func TestMoveCommand(t *testing.T) {
 	t.Parallel()
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("successful moves", func(t *testing.T) {
 		t.Parallel()
@@ -25,13 +17,13 @@ func TestMoveCommand(t *testing.T) {
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 			// Create branch1 -> branch2 -> branch3
 			for _, b := range []string{"branch1", "branch2", "branch3"} {
 				if err := s.Repo.CreateChange(b+" change", b, false); err != nil {
 					return err
 				}
-				runCliCommand(binaryPath, s.Dir, "create", b, "-m", b+" change")
+				runCliCommand(s.Dir, "create", b, "-m", b+" change")
 			}
 			return nil
 		})
@@ -39,7 +31,7 @@ func TestMoveCommand(t *testing.T) {
 		// 1. Move branch2 to main (downstack)
 		// Note: "Stack membership updated" messages only appear when branches have stack IDs
 		// which are only created when descriptions/scopes are set.
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "move", "--source", "branch2", "--onto", "main", "-y")
+		output := runCliCommandSuccess(t, scene.Dir, "move", "--source", "branch2", "--onto", "main", "-y")
 		normalized := testhelpers.NormalizeOutput(output)
 		require.Equal(t, testhelpers.NormalizeOutput(`
 Moved branch2 (current) from branch1 to main.
@@ -50,7 +42,7 @@ Restacked branch3 (current) on branch2.
 		// 2. Move current branch (branch3) to branch1 (different stack)
 		err := scene.Repo.CheckoutBranch("branch3")
 		require.NoError(t, err)
-		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "move", "--onto", "branch1", "-y")
+		output = runCliCommandSuccess(t, scene.Dir, "move", "--onto", "branch1", "-y")
 		require.Equal(t, testhelpers.NormalizeOutput(`
 Moved branch3 (current) from branch2 to branch1.
 Restacked branch3 (current) on branch1.
@@ -65,7 +57,7 @@ Restacked branch3 (current) on branch1.
 		err = scene.Repo.CreateChangeAndCommit("main change", "main")
 		require.NoError(t, err)
 
-		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "move", "--source", "branch1", "--onto", "main", "-y")
+		output = runCliCommandSuccess(t, scene.Dir, "move", "--source", "branch1", "--onto", "main", "-y")
 		require.Equal(t, testhelpers.NormalizeOutput(`
 Moved branch1 (current) from main to main.
 Restacked branch1 on main.
@@ -79,21 +71,21 @@ Restacked branch3 on branch1.
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 			// Create branch1 -> branch2
 			if err := s.Repo.CreateChange("branch1 change", "branch1", false); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "create", "branch1", "-m", "branch1 change")
+			runCliCommand(s.Dir, "create", "branch1", "-m", "branch1 change")
 			if err := s.Repo.CreateChange("branch2 change", "branch2", false); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "create", "branch2", "-m", "branch2 change")
+			runCliCommand(s.Dir, "create", "branch2", "-m", "branch2 change")
 			return nil
 		})
 
 		// Run dry-run move
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "move", "--source", "branch2", "--onto", "main", "--dry-run")
+		output := runCliCommandSuccess(t, scene.Dir, "move", "--source", "branch2", "--onto", "main", "--dry-run")
 		require.Contains(t, output, "Dry-run:")
 		require.Contains(t, output, "Move: branch2")
 		require.Contains(t, output, "From: branch1")
@@ -103,7 +95,7 @@ Restacked branch3 on branch1.
 		require.Contains(t, output, "Run without --dry-run to execute")
 
 		// Verify branch was NOT actually moved (still has branch1 as parent)
-		treeOutput := runCliCommandSuccess(t, binaryPath, scene.Dir, "tree")
+		treeOutput := runCliCommandSuccess(t, scene.Dir, "tree")
 		require.Contains(t, treeOutput, "branch2")
 		require.Contains(t, treeOutput, "branch1")
 	})
@@ -114,17 +106,15 @@ Restacked branch3 on branch1.
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 			if err := s.Repo.CreateChange("branch1 change", "branch1", false); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "create", "branch1", "-m", "branch1 change")
+			runCliCommand(s.Dir, "create", "branch1", "-m", "branch1 change")
 			return nil
 		})
 
-		cmd := exec.Command(binaryPath, "move", "--dry-run")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCliCommandOutput(scene.Dir, "move", "--dry-run")
 		require.Error(t, err)
 		require.Contains(t, string(output), "--onto flag is required when using --dry-run")
 	})
@@ -136,13 +126,13 @@ Restacked branch3 on branch1.
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 
 			// Create branch1 with a change to a file
 			if err := s.Repo.CreateChange("branch1 content", "conflict.txt", false); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "create", "branch1", "-m", "branch1 change")
+			runCliCommand(s.Dir, "create", "branch1", "-m", "branch1 change")
 
 			// Go back to main and create branch2 with conflicting change
 			if err := s.Repo.CheckoutBranch("main"); err != nil {
@@ -151,14 +141,12 @@ Restacked branch3 on branch1.
 			if err := s.Repo.CreateChange("branch2 content", "conflict.txt", false); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "create", "branch2", "-m", "branch2 change")
+			runCliCommand(s.Dir, "create", "branch2", "-m", "branch2 change")
 			return nil
 		})
 
 		// Try to move branch2 onto branch1 (will conflict)
-		cmd := exec.Command(binaryPath, "move", "--source", "branch2", "--onto", "branch1", "--dry-run")
-		cmd.Dir = scene.Dir
-		output, err := cmd.CombinedOutput()
+		output, err := runCliCommandOutput(scene.Dir, "move", "--source", "branch2", "--onto", "branch1", "--dry-run")
 		require.Error(t, err)
 		outputStr := string(output)
 		require.Contains(t, outputStr, "Dry-run:")
@@ -171,9 +159,9 @@ Restacked branch3 on branch1.
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
-			runCliCommand(binaryPath, s.Dir, "create", "branch1", "-m", "branch1")
-			runCliCommand(binaryPath, s.Dir, "create", "branch2", "-m", "branch2")
+			runCliCommand(s.Dir, "init")
+			runCliCommand(s.Dir, "create", "branch1", "-m", "branch1")
+			runCliCommand(s.Dir, "create", "branch2", "-m", "branch2")
 			return nil
 		})
 
@@ -215,9 +203,7 @@ Restacked branch3 on branch1.
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				cmd := exec.Command(binaryPath, tc.args...)
-				cmd.Dir = scene.Dir
-				output, err := cmd.CombinedOutput()
+				output, err := runCliCommandOutput(scene.Dir, tc.args...)
 				require.Error(t, err)
 				require.Contains(t, string(output), tc.expected)
 			})

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -12,13 +12,6 @@ import (
 
 func TestSubmitCommand(t *testing.T) {
 	t.Parallel()
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("dry-run output format", func(t *testing.T) {
 		t.Parallel()
@@ -26,9 +19,9 @@ func TestSubmitCommand(t *testing.T) {
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 			for _, b := range []string{"branch-a", "branch-b", "branch-c"} {
-				runCliCommand(binaryPath, s.Dir, "create", b)
+				runCliCommand(s.Dir, "create", b)
 			}
 			return s.Repo.CheckoutBranch("branch-b")
 		})
@@ -42,14 +35,14 @@ Will submit (2)
 ● branch-b → create (empty)
 Dry run complete
 `)
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		output := runCliCommandSuccess(t, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 
-		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive", "--verbose")
+		output = runCliCommandSuccess(t, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive", "--verbose")
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 
 		// 2. Submit --stack (full stack)
-		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--stack", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		output = runCliCommandSuccess(t, scene.Dir, "submit", "--stack", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		expectedStack := testhelpers.NormalizeOutput(`
 Submit plan → main
 Will submit (3)
@@ -61,7 +54,7 @@ Dry run complete
 		require.Equal(t, expectedStack, testhelpers.NormalizeOutput(output))
 
 		// 3. ss alias (same as submit --stack)
-		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "ss", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		output = runCliCommandSuccess(t, scene.Dir, "ss", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		require.Equal(t, expectedStack, testhelpers.NormalizeOutput(output), "ss alias should behave like submit --stack")
 	})
 
@@ -71,9 +64,9 @@ Dry run complete
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 			for _, b := range []string{"branch-a", "branch-b", "branch-c"} {
-				runCliCommand(binaryPath, s.Dir, "create", b)
+				runCliCommand(s.Dir, "create", b)
 			}
 			if _, err := s.Repo.CreateBareRemote("origin"); err != nil {
 				return err
@@ -101,7 +94,7 @@ Dry run complete
 			return s.Repo.CheckoutBranch("branch-b")
 		})
 
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "ss", "--no-edit", "--no-interactive")
+		output := runCliCommandSuccess(t, scene.Dir, "ss", "--no-edit", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
 ✓ Nothing to submit
 `)
@@ -114,14 +107,14 @@ Dry run complete
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
-			runCliCommand(binaryPath, s.Dir, "create", "solo-branch")
+			runCliCommand(s.Dir, "init")
+			runCliCommand(s.Dir, "create", "solo-branch")
 			return nil
 		})
 
 		// A lone branch off trunk reads as "name → base", with no "Stack to
 		// submit" header.
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		output := runCliCommandSuccess(t, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
 solo-branch → main  create (empty)
 Dry run complete
@@ -135,14 +128,14 @@ Dry run complete
 			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
 				return err
 			}
-			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(s.Dir, "init")
 			return nil
 		})
 
 		// On trunk with no stacked branches there is nothing to submit. Standing
 		// on trunk is surfaced distinctly: the action points the user at creating
 		// or checking out a branch rather than printing a bare "nothing to submit".
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--no-edit", "--no-interactive")
+		output := runCliCommandSuccess(t, scene.Dir, "submit", "--no-edit", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
 You're on main — nothing to submit from here.
 💡 Check out a branch to submit its stack, or create one:

--- a/internal/cli/stack/sync_test.go
+++ b/internal/cli/stack/sync_test.go
@@ -11,17 +11,10 @@ import (
 
 func TestSyncCommand(t *testing.T) {
 	t.Parallel()
-	binaryPath := testhelpers.GetSharedBinaryPath()
-	if binaryPath == "" {
-		if err := testhelpers.GetBinaryError(); err != nil {
-			t.Fatalf("failed to build stackit binary: %v", err)
-		}
-		t.Fatal("stackit binary not built")
-	}
 
 	t.Run("successful sync scenarios", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create a remote to avoid sync errors related to missing remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
@@ -77,7 +70,7 @@ func TestSyncCommand(t *testing.T) {
 
 	t.Run("sync failures and tips", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		// Create a remote to avoid sync errors related to missing remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
@@ -112,7 +105,7 @@ Error: you have uncommitted changes. Please commit or stash them before syncing
 
 	t.Run("dry-run previews without mutating", func(t *testing.T) {
 		t.Parallel()
-		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithInProcess(true)
 
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)

--- a/internal/cli/stack/test_helpers_test.go
+++ b/internal/cli/stack/test_helpers_test.go
@@ -1,24 +1,35 @@
 package stack_test
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers/inprocess"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
-func runCliCommand(binaryPath, dir string, args ...string) error {
-	cmd := exec.Command(binaryPath, args...)
-	cmd.Dir = dir
-	return cmd.Run()
+func init() {
+	scenario.SetGlobalInProcessRunner(func(workDir string, args ...string) (string, error) {
+		result := inprocess.NewInProcessCLI().Run(workDir, args...)
+		return result.Output, result.Err
+	})
 }
 
-func runCliCommandSuccess(t *testing.T, binaryPath, dir string, args ...string) string {
+func runCliCommand(dir string, args ...string) error {
+	_, err := runCliCommandOutput(dir, args...)
+	return err
+}
+
+func runCliCommandOutput(dir string, args ...string) ([]byte, error) {
+	result := inprocess.NewInProcessCLI().Run(dir, args...)
+	return []byte(result.Output), result.Err
+}
+
+func runCliCommandSuccess(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command(binaryPath, args...)
-	cmd.Dir = dir
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, "command failed: %s %v\nOutput: %s", binaryPath, args, string(output))
+	output, err := runCliCommandOutput(dir, args...)
+	require.NoError(t, err, "command failed: stackit %v\nOutput: %s", args, string(output))
 	return ansi.Strip(string(output))
 }

--- a/internal/engine/transaction_test.go
+++ b/internal/engine/transaction_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -500,92 +501,96 @@ func TestTransaction_ConcurrentModificationLocalMeta(t *testing.T) {
 
 func TestWithRetry_RetriesOnConcurrentModification(t *testing.T) {
 	t.Parallel()
-	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	synctest.Test(t, func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-	// Create and track a branch
-	s.CreateBranch("feature-1").
-		Commit("feature 1 change")
-	err := s.Engine.TrackBranch(context.Background(), "feature-1", "main")
-	require.NoError(t, err)
+		// Create and track a branch
+		s.CreateBranch("feature-1").
+			Commit("feature 1 change")
+		err := s.Engine.TrackBranch(context.Background(), "feature-1", "main")
+		require.NoError(t, err)
 
-	// Get the engine implementation
-	eng := s.Engine.(interface {
-		WithRetry(ctx context.Context, operation func() error) error
-		BeginTx(message string) *engine.MetadataTx
-		Git() git.Runner
+		// Get the engine implementation
+		eng := s.Engine.(interface {
+			WithRetry(ctx context.Context, operation func() error) error
+			BeginTx(message string) *engine.MetadataTx
+			Git() git.Runner
+		})
+
+		attemptCount := 0
+		maxFailures := 2 // Fail first 2 attempts, succeed on 3rd
+
+		err = eng.WithRetry(context.Background(), func() error {
+			attemptCount++
+
+			tx := eng.BeginTx("retry test")
+			meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
+			if stageErr := tx.UpdateMeta("feature-1", meta); stageErr != nil {
+				return stageErr
+			}
+
+			// Simulate concurrent modification for first N attempts
+			// Use different scope values to ensure different blob SHAs
+			if attemptCount <= maxFailures {
+				scope := fmt.Sprintf("conflict-%d", attemptCount)
+				otherMeta := git.NewMetaFrom(git.MetaFields{Scope: &scope})
+				if writeErr := eng.Git().WriteMetadata("feature-1", otherMeta); writeErr != nil {
+					return writeErr
+				}
+			}
+
+			return tx.Commit(context.Background())
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, maxFailures+1, attemptCount, "expected %d attempts", maxFailures+1)
 	})
+}
 
-	attemptCount := 0
-	maxFailures := 2 // Fail first 2 attempts, succeed on 3rd
+func TestWithRetry_ExhaustsRetries(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-	err = eng.WithRetry(context.Background(), func() error {
-		attemptCount++
+		// Create and track a branch
+		s.CreateBranch("feature-1").
+			Commit("feature 1 change")
+		err := s.Engine.TrackBranch(context.Background(), "feature-1", "main")
+		require.NoError(t, err)
 
-		tx := eng.BeginTx("retry test")
-		meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
-		if stageErr := tx.UpdateMeta("feature-1", meta); stageErr != nil {
-			return stageErr
-		}
+		// Get the engine implementation
+		eng := s.Engine.(interface {
+			WithRetry(ctx context.Context, operation func() error) error
+			BeginTx(message string) *engine.MetadataTx
+			Git() git.Runner
+		})
 
-		// Simulate concurrent modification for first N attempts
-		// Use different scope values to ensure different blob SHAs
-		if attemptCount <= maxFailures {
+		attemptCount := 0
+
+		err = eng.WithRetry(context.Background(), func() error {
+			attemptCount++
+
+			tx := eng.BeginTx("exhaustion test")
+			meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
+			if stageErr := tx.UpdateMeta("feature-1", meta); stageErr != nil {
+				return stageErr
+			}
+
+			// Always cause concurrent modification with unique content - never succeed
 			scope := fmt.Sprintf("conflict-%d", attemptCount)
 			otherMeta := git.NewMetaFrom(git.MetaFields{Scope: &scope})
 			if writeErr := eng.Git().WriteMetadata("feature-1", otherMeta); writeErr != nil {
 				return writeErr
 			}
-		}
 
-		return tx.Commit(context.Background())
+			return tx.Commit(context.Background())
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed after")
+		assert.Contains(t, err.Error(), "retries")
+		assert.Equal(t, engine.MaxRetries, attemptCount, "expected exactly %d attempts", engine.MaxRetries)
 	})
-
-	require.NoError(t, err)
-	assert.Equal(t, maxFailures+1, attemptCount, "expected %d attempts", maxFailures+1)
-}
-
-func TestWithRetry_ExhaustsRetries(t *testing.T) {
-	t.Parallel()
-	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-
-	// Create and track a branch
-	s.CreateBranch("feature-1").
-		Commit("feature 1 change")
-	err := s.Engine.TrackBranch(context.Background(), "feature-1", "main")
-	require.NoError(t, err)
-
-	// Get the engine implementation
-	eng := s.Engine.(interface {
-		WithRetry(ctx context.Context, operation func() error) error
-		BeginTx(message string) *engine.MetadataTx
-		Git() git.Runner
-	})
-
-	attemptCount := 0
-
-	err = eng.WithRetry(context.Background(), func() error {
-		attemptCount++
-
-		tx := eng.BeginTx("exhaustion test")
-		meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
-		if stageErr := tx.UpdateMeta("feature-1", meta); stageErr != nil {
-			return stageErr
-		}
-
-		// Always cause concurrent modification with unique content - never succeed
-		scope := fmt.Sprintf("conflict-%d", attemptCount)
-		otherMeta := git.NewMetaFrom(git.MetaFields{Scope: &scope})
-		if writeErr := eng.Git().WriteMetadata("feature-1", otherMeta); writeErr != nil {
-			return writeErr
-		}
-
-		return tx.Commit(context.Background())
-	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed after")
-	assert.Contains(t, err.Error(), "retries")
-	assert.Equal(t, engine.MaxRetries, attemptCount, "expected exactly %d attempts", engine.MaxRetries)
 }
 
 func TestWithRetry_NonRetryableError(t *testing.T) {

--- a/internal/engine/worktree_prune_internal_test.go
+++ b/internal/engine/worktree_prune_internal_test.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+type failingPruneRunner struct {
+	git.Runner
+	calls int
+}
+
+func (g *failingPruneRunner) PruneWorktrees(context.Context) error {
+	g.calls++
+	return errors.New("prune failed")
+}
+
+func TestTemporaryWorktreePruneFailureIsRetried(t *testing.T) {
+	t.Parallel()
+	g := &failingPruneRunner{}
+	e := &engineImpl{git: g, tempWorktreeNeedsPrune: true}
+
+	e.maybePruneTempWorktreesLocked(t.Context(), WorktreePruneAuto)
+	e.maybePruneTempWorktreesLocked(t.Context(), WorktreePruneAuto)
+
+	require.Equal(t, 2, g.calls, "a failed prune must not suppress the next attempt")
+	require.True(t, e.tempWorktreeNeedsPrune)
+	require.False(t, e.tempWorktreePrunedOnce)
+}

--- a/mise.toml
+++ b/mise.toml
@@ -126,14 +126,14 @@ run = "scripts/check-quiet.sh test:fresh"
 description = "Run tests with verbose output"
 run = """
   PACKAGES=$(bash scripts/go-test-packages.sh all)
-  gotestsum --format standard-verbose -- $PACKAGES
+  bash scripts/with-test-binary.sh gotestsum --format standard-verbose -- $PACKAGES
 """
 
 [tasks."test:coverage"]
 description = "Run tests with coverage"
 run = """
   PACKAGES=$(bash scripts/go-test-packages.sh all)
-  gotestsum --format pkgname-and-test-fails -- -coverprofile=coverage.out $PACKAGES
+  bash scripts/with-test-binary.sh gotestsum --format pkgname-and-test-fails -- -coverprofile=coverage.out $PACKAGES
   go tool cover -html=coverage.out -o coverage.html
 """
 

--- a/scripts/check-quiet.sh
+++ b/scripts/check-quiet.sh
@@ -140,10 +140,15 @@ go_test() {
     repro="mise run test:$tier"
   fi
 
+  local -a runner=(gotestsum)
+  case "$tier" in
+    all | git | integration) runner=(bash scripts/with-test-binary.sh gotestsum) ;;
+  esac
+
   run_phase \
     "test:$tier" \
     "$repro" \
-    gotestsum \
+    "${runner[@]}" \
       --format standard-quiet \
       --hide-summary=skipped,output \
       -- \

--- a/scripts/with-test-binary.sh
+++ b/scripts/with-test-binary.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build one CLI for all test packages, then run the supplied test command.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: bash scripts/with-test-binary.sh <command> [args...]" >&2
+  exit 2
+fi
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache_root="$(go env GOCACHE)/stackit-test-binaries"
+mkdir -p "$cache_root"
+build_dir="$(mktemp -d "$cache_root/build.XXXXXX")"
+trap 'rm -rf "$build_dir"' EXIT
+
+(
+  cd "$project_root"
+  go build -o "$build_dir/stackit" ./apps/cli
+)
+
+# A content-addressed path changes when the CLI changes, but stays stable on
+# unchanged runs so Go can reuse test results. Never replace a binary being
+# used by a concurrent suite running against a different revision.
+binary_id="$(git hash-object "$build_dir/stackit")"
+binary_dir="$cache_root/$binary_id"
+mkdir -p "$binary_dir"
+if [ ! -x "$binary_dir/stackit" ]; then
+  mv "$build_dir/stackit" "$binary_dir/stackit"
+fi
+
+export STACKIT_TEST_BINARY="$binary_dir/stackit"
+"$@"

--- a/testhelpers/binary.go
+++ b/testhelpers/binary.go
@@ -63,43 +63,8 @@ func GetBinaryError() error {
 
 // buildBinary builds the stackit binary and returns its path.
 func buildBinary() (string, error) {
-	// Find the module root by walking up from the current directory
-	// looking for go.mod file
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	moduleRoot := findModuleRoot(wd)
-	if moduleRoot == "" {
-		return "", fmt.Errorf("could not find module root (go.mod) starting from %s", wd)
-	}
-
-	// Create temp directory for binary
-	tmpDir, err := os.MkdirTemp("", "stackit-test-binary-*")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp directory: %w", err)
-	}
-
-	binaryPath := filepath.Join(tmpDir, "stackit")
-
-	// Build the binary
-	cmd := exec.Command("go", "build", "-o", binaryPath, "./apps/cli")
-	cmd.Dir = moduleRoot
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		_ = os.RemoveAll(tmpDir) // Ignore cleanup errors
-		return "", fmt.Errorf("failed to build: %s: %w", string(output), err)
-	}
-
-	// Make it executable
-	//nolint:gosec // 0755 is correct for an executable binary
-	if err := os.Chmod(binaryPath, 0755); err != nil {
-		_ = os.RemoveAll(tmpDir) // Ignore cleanup errors
-		return "", fmt.Errorf("failed to chmod: %w", err)
-	}
-
-	return binaryPath, nil
+	path, _, err := buildBinaryOnce()
+	return path, err
 }
 
 // findModuleRoot walks up the directory tree from startDir to find the module root
@@ -148,6 +113,21 @@ func TestMain(m *testing.M, cleanup func()) {
 
 // buildBinaryOnce builds the stackit binary once and returns its path and cleanup function.
 func buildBinaryOnce() (string, func(), error) {
+	if path := os.Getenv("STACKIT_TEST_BINARY"); path != "" {
+		if !filepath.IsAbs(path) {
+			return "", nil, fmt.Errorf("STACKIT_TEST_BINARY must be an absolute path: %s", path)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid STACKIT_TEST_BINARY: %w", err)
+		}
+		if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+			return "", nil, fmt.Errorf("STACKIT_TEST_BINARY is not an executable file: %s", path)
+		}
+		// The runner owns this binary; individual packages must not delete it.
+		return path, func() {}, nil
+	}
+
 	// Get the module root (go up from current directory to stackit root)
 	wd, err := os.Getwd()
 	if err != nil {

--- a/testhelpers/binary_test.go
+++ b/testhelpers/binary_test.go
@@ -1,0 +1,49 @@
+package testhelpers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBinaryUsesCallerOwnedBinary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stackit")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("STACKIT_TEST_BINARY", path)
+
+	got, cleanup, err := buildBinaryOnce()
+	require.NoError(t, err)
+	require.Equal(t, path, got)
+	cleanup()
+	require.FileExists(t, path, "test packages must not remove the suite's binary")
+
+	got, err = buildBinary()
+	require.NoError(t, err)
+	require.Equal(t, path, got, "lazy callers must use the same binary")
+}
+
+func TestBuildBinaryRejectsInvalidOverride(t *testing.T) {
+	dir := t.TempDir()
+	notExecutable := filepath.Join(dir, "not-executable")
+	require.NoError(t, os.WriteFile(notExecutable, nil, 0o600))
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"relative path", "relative/stackit"},
+		{"missing file", filepath.Join(dir, "missing")},
+		{"directory", dir},
+		{"not executable", notExecutable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("STACKIT_TEST_BINARY", tc.path)
+			path, cleanup, err := buildBinaryOnce()
+			require.ErrorContains(t, err, "STACKIT_TEST_BINARY")
+			require.Empty(t, path)
+			require.Nil(t, cleanup)
+		})
+	}
+}


### PR DESCRIPTION
Tests repeatedly waited for real CI-registration and retry delays, and separate packages built and launched the same CLI. This change advances those test clocks with `testing/synctest`, builds one content-addressed CLI per suite invocation, and runs create, navigation, sync, move, and submit scenarios through the existing in-process harness.

All scenario inputs and assertions remain. Other CLI tests retain subprocess coverage, direct package tests retain lazy builds, and stable binary paths preserve Go's test-result cache. The shared runner is wired into the all/git/integration tasks, verbose/coverage tasks, and CI; fast/unit tasks skip the prebuild. Production behavior is unchanged.

### Before and after

Measured locally on Go 1.26.7 with six available CPUs, warm compilation caches, test-result caching disabled, and no competing validation runs. The full-runner figures are medians of three invocations of `scripts/check-quiet.sh test:fresh`, including package selection and the shared build.

| Measurement | Before | After |
| --- | ---: | ---: |
| Full Go runner, median of 3 | 34.483s | 33.794s |
| Navigation package | 3.489s | 1.063s |
| Branch package | 5.071s | 2.766s |
| Stack package | 8.998s | 5.679s |
| Each CI wait case | 5.00s | <0.01s |
| Retry exhaustion case | 3.74s | 0.20s |

Package/test figures compare the median of three baseline full-suite JSON runs with one final full-suite JSON run; they are directional, not repeated isolated benchmarks. Total improvement is about **2%**, despite larger gains in the affected packages: unchanged integration and Git work dominate the suite, and package times overlap.

### Validation

- `mise run check:go` passed (formatting, lint, full Go suite).
- Converted CLI packages passed twice with `-race -p=1 -parallel=2`; timer/retry tests passed three race runs.
- Covered-block guards passed for the timer and CLI conversion stages. The conversion-stage coverage sample rose from 31.6% to 34.6% because in-process execution now records CLI coverage. A deterministic prune-failure test replaces dependence on a sporadically exercised error path in the coverage sample.
- Shared-binary ownership/invalid-path tests, cache reuse, concurrent runners, and ShellCheck passed.
- Final uncached JSON run passed, with the same four existing skips.

Some timing repeats hit intermittent Git tests: baseline failures in `TestPullBranch_Reproduction` and `TestPullBranch_WorkingDirSyncWhenOnBranch`, and an after-run failure in `TestFetch_ForceUpdatedRemoteBranch`. All three passed 20 isolated repetitions each; the final full JSON run and `check:go` passed. This change does not claim to fix those intermittent failures.
