### PR TITLE
fix(get): skip branches held elsewhere, never rebase an unanchored one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,12 @@ jobs:
           mkdir -p bin
           go build -v -o bin/stackit ./apps/cli
           pnpm --filter @stackit/web build
+          # sync-web-static.sh falls back to a placeholder page when the export
+          # is missing, so that the server still builds on a fresh clone. That
+          # makes a silently no-op'd web build (pnpm --filter exits 0 when the
+          # filter matches nothing) look like success here. Assert the export
+          # the same way the goreleaser configs do.
+          test -f apps/web/out/index.html
           ./scripts/sync-web-static.sh
           go build -v -o bin/stackit-server ./apps/server
           if [ -d ./apps/st-tui ]; then

--- a/README.md
+++ b/README.md
@@ -531,6 +531,13 @@ as behind nor proven current. When `trunk_state_unknown` is `true`, an absent
 `would_pull` does **not** mean trunk is up to date; fetch and re-run before
 acting on the preview.
 
+**`stackit submit --json` reports native GitHub Stacks as arrays.** A submit can
+reconcile more than one native Stack, since chains are synced independently.
+Every reconciled Stack appears in `github_stacks`, and every skipped one in
+`github_stack_skips`. The older scalar fields `github_stack` and
+`github_stack_skipped` are populated **only when there is exactly one** — with
+two or more they are omitted entirely, so scripts should read the arrays.
+
 Two smaller shapes changed alongside the worktree work. `stackit tree --json`
 has always omitted worktree anchors from its entries, but `parent` could still
 name one — a dangling reference to a branch absent from the result. Both

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -472,6 +472,15 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		})
 	}
 
+	// Updating an existing branch needs it at HEAD, and git refuses to check
+	// out a branch another worktree holds. Resolve the holders once up front so
+	// those branches are reported and skipped, rather than aborting the run
+	// partway through with the earlier branches already updated.
+	heldElsewhere, err := branchesHeldByOtherWorktrees(gctx, eng)
+	if err != nil {
+		out.Debug("Could not inspect worktrees; no branch will be skipped: %v", err)
+	}
+
 	// Sync each branch
 	for _, branchName := range targets.branches {
 		if branchName == eng.Trunk().GetName() {
@@ -519,6 +528,19 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				IsNew:    true,
 			})
 		} else {
+			// Another worktree holds this branch, so it cannot come to HEAD
+			// here. Leave both its content and its metadata alone: updating the
+			// recorded parent for content we could not fetch is exactly the
+			// ref/worktree divergence the worktree rules exist to prevent.
+			if path, held := heldElsewhere[branchName]; held {
+				handler.EmitEvent(GetEvent{
+					Phase:   GetPhaseSync,
+					Type:    GetEventSkipped,
+					Branch:  branchName,
+					Message: fmt.Sprintf("checked out in worktree %s", path),
+				})
+				continue
+			}
 			// Both updates below act on the branch that is currently checked
 			// out: `git reset --hard` moves HEAD's branch, and a merge lands in
 			// HEAD's branch. Without this checkout, running get while trunk is
@@ -564,11 +586,21 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// a frozen branch is never rebased — restack skips it and resets it to the
 	// remote instead. Explain that, and let the user opt into unfreezing so the
 	// restack phase below can finish the job.
+	// Branches re-anchored without a divergence anchor must never be rebased:
+	// the replay range still starts before the landed commits, so restacking
+	// reintroduces them instead of dropping them. Freezing normally keeps
+	// restack off them, but --unfrozen skips the freeze entirely, so the
+	// restack phase below excludes them by name rather than trusting the freeze.
+	unanchored := make(map[string]bool)
+
 	if len(reanchored) > 0 {
 		report := LandedAncestorReport{
 			Reanchored: targets.reanchoredInSyncOrder(reanchored),
 			Stale:      targets.staleAfterReanchor(eng, reanchored, freezeSet),
 			CanRestack: opts.Restack,
+		}
+		for _, name := range report.Unanchored() {
+			unanchored[name] = true
 		}
 		decision, err := handler.ReportLandedAncestors(report)
 		if err != nil {
@@ -617,6 +649,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		for _, name := range targets.branches {
 			if !seen[name] {
 				seen[name] = true
+				if unanchored[name] {
+					continue
+				}
 				b := eng.GetBranch(name)
 				if b.IsTracked() {
 					uniqueBranches.Add(b)
@@ -700,6 +735,33 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	})
 
 	return nil
+}
+
+// branchesHeldByOtherWorktrees maps each branch checked out somewhere other
+// than here to the worktree path holding it.
+//
+// No path comparison is needed to decide what "here" means: git allows a branch
+// to be checked out in one worktree at a time, so the only entry this worktree
+// can own is the current branch. Everything else in the list is elsewhere.
+//
+// A worktree listing that cannot be read holds nothing back — get then behaves
+// as it did before, failing on the checkout if a branch really is held.
+func branchesHeldByOtherWorktrees(ctx context.Context, eng engine.Engine) (map[string]string, error) {
+	worktrees, err := eng.ListWorktrees(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	current := eng.CurrentBranchName()
+	held := make(map[string]string, len(worktrees))
+	for _, wt := range worktrees {
+		// A detached worktree reports no branch, and so holds none.
+		if wt.Branch == "" || wt.Branch == current {
+			continue
+		}
+		held[wt.Branch] = wt.Path
+	}
+	return held, nil
 }
 
 // localBranchSet reports whether a branch name exists locally. engine.BranchSet

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -238,6 +238,16 @@ func (h *SimpleGetHandler) printFetchEvent(event actions.GetEvent) {
 }
 
 func (h *SimpleGetHandler) printSyncEvent(event actions.GetEvent) {
+	// A skipped branch is the one case where saying nothing is wrong: the
+	// branch silently keeps its old content, and the remedy lives in another
+	// worktree the user is not looking at.
+	if event.Type == actions.GetEventSkipped {
+		h.Output.Warn("  Skipped %s: %s",
+			style.ColorBranchName(event.Branch),
+			event.Message)
+		return
+	}
+
 	if event.Type != actions.GetEventCompleted {
 		return
 	}

--- a/internal/integration/get_held_worktree_test.go
+++ b/internal/integration/get_held_worktree_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	syncaction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// skipRecordingGetHandler captures the branches get reported as skipped, with
+// the message explaining why. EmitEvent is only called from get's sequential
+// sync loop, so no locking is needed.
+type skipRecordingGetHandler struct {
+	actions.GetNullHandler
+	skipped map[string]string
+}
+
+func (h *skipRecordingGetHandler) EmitEvent(e actions.GetEvent) {
+	if e.Type != actions.GetEventSkipped {
+		return
+	}
+	if h.skipped == nil {
+		h.skipped = map[string]string{}
+	}
+	h.skipped[e.Branch] = e.Message
+}
+
+// Updating an existing branch brings it to HEAD, and git refuses to check out a
+// branch another worktree holds. get used to return that error from inside its
+// sync loop, having already updated the branches before it — leaving the run
+// half-applied and HEAD on a branch the user never asked for.
+//
+// The branches it can sync must still sync, and the one it cannot must be named
+// along with the worktree holding it: the remedy lives in a directory the user
+// is not looking at.
+func TestGetSkipsBranchHeldByAnotherWorktree(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+
+	// Build main -> a -> b and push metadata, so get can resolve b's ancestry
+	// and pull a into the same sync set.
+	sh.CreateBranch("a").CommitChange("a.txt", "a").TrackBranch("a", "main")
+	sh.CreateBranch("b").CommitChange("b.txt", "b").TrackBranch("b", "a")
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	sh.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	require.NoError(t, submit.Action(sh.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{}))
+	require.NoError(t, syncaction.Action(sh.Context, syncaction.Options{}, nil))
+
+	// Park a in a plain git worktree. Both a and b already exist locally, so
+	// get takes the update path for each and needs them at HEAD in turn.
+	sh.Checkout("b")
+	worktreeDir := t.TempDir()
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("worktree", "add", worktreeDir, "a"))
+	sh.Rebuild()
+
+	aBefore, err := sh.Scene.Repo.GetRevision("a")
+	require.NoError(t, err)
+
+	handler := &skipRecordingGetHandler{}
+	require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: false}, handler),
+		"a branch held elsewhere must not fail the whole run")
+	sh.Rebuild()
+
+	require.Contains(t, handler.skipped, "a", "the held branch must be reported, not silently passed over")
+	require.Contains(t, handler.skipped["a"], worktreeDir,
+		"the report has to name the worktree holding it")
+
+	aAfter, err := sh.Scene.Repo.GetRevision("a")
+	require.NoError(t, err)
+	require.Equal(t, aBefore, aAfter, "a is left exactly as its worktree has it")
+
+	// The branch get was actually asked for still lands, and HEAD ends on it
+	// rather than wherever the loop happened to stop.
+	require.Equal(t, "b", sh.Engine.CurrentBranchName())
+}

--- a/internal/integration/get_landed_parent_test.go
+++ b/internal/integration/get_landed_parent_test.go
@@ -345,6 +345,31 @@ func TestGetPastLandedParentWithNoMetadataAtAll(t *testing.T) {
 	requireCleanWorkingTree(t, sh)
 }
 
+// --unfrozen skips the freeze that otherwise keeps restack off an unanchored
+// branch. The exclusion must therefore be keyed on the missing anchor itself,
+// not on the freeze: rebasing here replays the landed commits rather than
+// dropping them, which is the data-loss shape re-anchoring exists to avoid.
+func TestGetPastLandedParentUnfrozenLeavesUnanchoredAlone(t *testing.T) {
+	t.Parallel()
+	sh := stackWithLandedParent(t, squashLanding, forgetAllMetadata)
+
+	handler := &landedParentHandler{decision: actions.UnfreezeAndRestack}
+	require.NoError(t, actions.GetAction(sh.Context, "b",
+		actions.GetOptions{Restack: true, Unfrozen: true}, handler))
+	sh.Rebuild()
+
+	require.Len(t, handler.reports, 1)
+	require.Equal(t, []string{"b"}, handler.reports[0].Unanchored(),
+		"nothing recorded a's tip, so b has no safe replay range")
+
+	sh.ExpectStackStructure(map[string]string{"b": "main"})
+	require.False(t, sh.Engine.GetBranch("b").IsFrozen(),
+		"--unfrozen still leaves the branch unfrozen; the anchor is what protects it")
+	require.Equal(t, 3, commitsInB(t, sh),
+		"b keeps its own commits instead of replaying the landed parent's")
+	requireCleanWorkingTree(t, sh)
+}
+
 // --restack=false leaves nothing for an unfreeze to feed, so get must not act
 // on a handler that asks for one anyway.
 func TestGetPastLandedParentWithoutRestack(t *testing.T) {


### PR DESCRIPTION

Follow-ups from the v0.27.0 pre-release review.

get brings each existing branch to HEAD before updating it, and git
refuses to check out a branch another worktree holds. That error came
back from inside the sync loop, after the earlier branches had already
been updated, leaving the run half-applied and HEAD on a branch the user
never asked for. Resolve the holders once up front, then report and skip
those branches so the rest still sync. Their metadata is left alone too:
updating a recorded parent for content that could not be fetched is the
ref/worktree divergence the worktree rules exist to prevent.

Separately, a branch re-anchored past a landed parent with no recorded
anchor was protected only by being frozen. --unfrozen skips that freeze
and --restack defaults on, so the restack phase rebased it and replayed
the landed commits -- the data-loss shape re-anchoring exists to avoid,
and the one multiplayer-safety.md explicitly forbids. Exclude unanchored
branches from the restack set by name, so the missing anchor is what
protects them rather than the freeze. Both fixes carry a test that fails
without them.

Also document submit --json's github_stacks/github_stack_skips arrays,
noting the legacy scalars are populated only for a single reconciled
Stack, and give the release workflow's build job the same web-export
assert the two goreleaser configs already have.