### PR TITLE
perf(absorb): batch commit-log fetches in preview output

### DIFF
--- a/internal/actions/absorb/output.go
+++ b/internal/actions/absorb/output.go
@@ -46,6 +46,8 @@ func printAbsorbPreview(
 	// Resolve owning branches in one batched scan instead of one lookup per commit.
 	commitSHAs := sortedCommitSHAs(hunksByCommit)
 	commitBranches := eng.FindBranchesForCommits(commitSHAs)
+	// Fetch each owning branch's commit log once instead of once per commit.
+	branchCommits := eng.BatchCommits(branchesFor(eng, commitBranches), engine.CommitFormatReadable)
 	for _, commitSHA := range commitSHAs {
 		hunks := sortedHunks(hunksByCommit[commitSHA])
 		branchName := commitBranches[commitSHA]
@@ -54,7 +56,7 @@ func printAbsorbPreview(
 		}
 
 		splog.Info("  %s  %s", shortSHA(commitSHA), output.BranchName(branchName))
-		if subject := commitSubject(eng, branchName, commitSHA); subject != "" {
+		if subject := commitSubject(branchCommits[branchName], commitSHA); subject != "" {
 			splog.Info("    %s", subject)
 		}
 		for _, hunk := range hunks {
@@ -202,16 +204,24 @@ func shortSHA(commitSHA string) string {
 	return commitSHA[:8]
 }
 
-func commitSubject(eng engine.Engine, branchName, commitSHA string) string {
-	if branchName == unknown {
-		return ""
+// branchesFor returns the distinct, resolved owning branches from a
+// commit-SHA-to-branch-name map, suitable for a single BatchCommits call.
+func branchesFor(eng engine.Engine, commitBranches map[string]string) engine.Branches {
+	seen := make(map[string]bool, len(commitBranches))
+	branches := make(engine.Branches, 0, len(commitBranches))
+	for _, branchName := range commitBranches {
+		if branchName == "" || branchName == unknown || seen[branchName] {
+			continue
+		}
+		seen[branchName] = true
+		branches = append(branches, eng.GetBranch(branchName))
 	}
-	branch := eng.GetBranch(branchName)
-	commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
-	if err != nil {
-		return ""
-	}
+	return branches
+}
 
+// commitSubject finds the subject line for commitSHA within a branch's
+// already-fetched commit log.
+func commitSubject(commits []string, commitSHA string) string {
 	for _, commit := range commits {
 		fields := strings.Fields(commit)
 		if len(fields) == 0 {

--- a/internal/actions/absorb/output_test.go
+++ b/internal/actions/absorb/output_test.go
@@ -1,0 +1,49 @@
+package absorb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestPrintAbsorbPreviewMultipleCommitsSameBranch(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"branch-a": "main",
+		})
+
+	s.Checkout("branch-a")
+	s.Scene.Repo.CreateChangeAndCommit("first commit", "file-a")
+	s.Scene.Repo.CreateChangeAndCommit("second commit", "file-b")
+
+	commits, err := s.Engine.GetBranch("branch-a").GetAllCommits(engine.CommitFormatSHA)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(commits), 2)
+	// GetAllCommits returns newest-first; "first commit" was made before
+	// "second commit".
+	secondSHA, firstSHA := commits[0], commits[1]
+
+	hunksByCommit := map[string][]git.Hunk{
+		firstSHA: {
+			{File: "file-a", NewStart: 1, NewCount: 1, Content: "+a"},
+		},
+		secondSHA: {
+			{File: "file-b", NewStart: 1, NewCount: 1, Content: "+b"},
+		},
+	}
+
+	out := output.NewTestOutput()
+	printAbsorbPlan(hunksByCommit, nil, s.Engine, out)
+
+	printed := out.String()
+	require.Contains(t, printed, "first commit")
+	require.Contains(t, printed, "second commit")
+}


### PR DESCRIPTION
## Summary

- `printAbsorbPreview` (used by both `absorb --dry-run` and the real absorb plan output) fetched a branch's *entire* commit log once per commit being absorbed into it, via `commitSubject` → `branch.GetAllCommits`.
- Absorb routinely maps several hunks/commits onto the same branch, so a branch receiving N absorbed commits triggered N redundant full-log git fetches for that same branch — the N+1 pattern called out in `.claude/rules/code-style.md`.
- Fixed by resolving each distinct owning branch's commit log once via the engine's existing `BatchCommits` API (used elsewhere for exactly this purpose), and looking up each commit's subject from that already-fetched slice.
- Checked for the same "call `GetAllCommits` once per commit, for one branch" pattern elsewhere in the codebase; other `GetAllCommits` call sites fetch once per branch (not per commit), so this was the only place exhibiting the N+1 shape.

## Test plan

- [x] Added `internal/actions/absorb/output_test.go`, covering two commits absorbed into the same branch, asserting both commit subjects are printed correctly from the batched lookup.
- [x] `go test ./internal/actions/absorb/...`
- [x] `go build ./...`
- [x] `go vet ./internal/actions/absorb/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122qtMYeyKLhKNeiFvrcvV3

---
_Generated by [Claude Code](https://claude.ai/code/session_0122qtMYeyKLhKNeiFvrcvV3)_