### PR TITLE
perf(doctor): batch orphaned metadata-ref deletion

### DIFF
--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -32,23 +32,32 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 		branchSet[branch] = true
 	}
 
-	orphanedCount := 0
-	prunedCount := 0
+	var orphanedBranches []string
 	for branchName := range metadataRefs {
 		if !branchSet[branchName] {
-			orphanedCount++
-			if fix {
-				if err := eng.DeleteMetadataRef(ctx, branchName); err != nil {
-					warnings++
-					handler.OnCheck("orphaned_metadata", CheckWarning, fmt.Sprintf("orphaned metadata for '%s' (fix failed: %v)", branchName, err))
-				} else {
-					prunedCount++
-					handler.OnCheck("orphaned_metadata", CheckPassed, fmt.Sprintf("Pruned orphaned metadata for deleted branch %s", branchName))
-				}
-			} else {
-				warnings++
+			orphanedBranches = append(orphanedBranches, branchName)
+		}
+	}
+	orphanedCount := len(orphanedBranches)
+	prunedCount := 0
+
+	switch {
+	case orphanedCount == 0:
+		// Nothing orphaned; skip straight to the summary below.
+	case fix:
+		if err := eng.DeleteMetadataRefsBatch(ctx, orphanedBranches); err != nil {
+			warnings += orphanedCount
+			for _, branchName := range orphanedBranches {
+				handler.OnCheck("orphaned_metadata", CheckWarning, fmt.Sprintf("orphaned metadata for '%s' (fix failed: %v)", branchName, err))
+			}
+		} else {
+			prunedCount = orphanedCount
+			for _, branchName := range orphanedBranches {
+				handler.OnCheck("orphaned_metadata", CheckPassed, fmt.Sprintf("Pruned orphaned metadata for deleted branch %s", branchName))
 			}
 		}
+	default:
+		warnings += orphanedCount
 	}
 
 	if orphanedCount > 0 {

--- a/internal/actions/doctor/stack_state_test.go
+++ b/internal/actions/doctor/stack_state_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,4 +23,36 @@ func TestCheckEmptyBranches(t *testing.T) {
 	empty := checkEmptyBranches(s.Engine)
 
 	require.ElementsMatch(t, []string{"nochanges"}, empty)
+}
+
+func TestCheckStackStatePrunesOrphanedMetadataInOneBatch(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"orphan1": "main",
+			"orphan2": "main",
+		}).
+		Checkout("main").
+		RunGit("branch", "-D", "orphan1").
+		RunGit("branch", "-D", "orphan2")
+
+	h := &recordingHandler{}
+	warnings, errors := checkStackState(context.Background(), s.Engine, h, 0, 0, true)
+
+	require.Equal(t, 0, errors)
+	require.Equal(t, 0, warnings)
+
+	var messages []string
+	for _, c := range h.checks {
+		messages = append(messages, c.message)
+	}
+	require.Contains(t, messages, "Pruned orphaned metadata for deleted branch orphan1")
+	require.Contains(t, messages, "Pruned orphaned metadata for deleted branch orphan2")
+	require.Contains(t, messages, "All 2 orphaned metadata ref(s) pruned")
+
+	refs, err := s.Engine.ListMetadataRefs()
+	require.NoError(t, err)
+	require.NotContains(t, refs, "orphan1")
+	require.NotContains(t, refs, "orphan2")
 }

--- a/internal/actions/doctor/stack_state_test.go
+++ b/internal/actions/doctor/stack_state_test.go
@@ -43,7 +43,7 @@ func TestCheckStackStatePrunesOrphanedMetadataInOneBatch(t *testing.T) {
 	require.Equal(t, 0, errors)
 	require.Equal(t, 0, warnings)
 
-	var messages []string
+	messages := make([]string, 0, len(h.checks))
 	for _, c := range h.checks {
 		messages = append(messages, c.message)
 	}

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -302,6 +302,17 @@ func (e *engineImpl) DeleteMetadataRef(ctx context.Context, branchName string) e
 	return e.git.DeleteMetadata(ctx, branchName)
 }
 
+// DeleteMetadataRefsBatch deletes many branches' metadata refs in a single
+// atomic git call. Same use case as DeleteMetadataRef, batched for callers
+// pruning more than one orphaned ref at a time.
+func (e *engineImpl) DeleteMetadataRefsBatch(ctx context.Context, branchNames []string) error {
+	refNames := make([]string, len(branchNames))
+	for i, branchName := range branchNames {
+		refNames[i] = git.MetadataRefPrefix + branchName
+	}
+	return e.git.DeleteRefsBatch(ctx, refNames)
+}
+
 // IsInsideRepo checks if the current directory is inside a git repository
 func (e *engineImpl) IsInsideRepo() bool {
 	return e.git.IsInsideRepo()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -421,6 +421,10 @@ type MetadataInspector interface {
 	// the transactional rebuild performed by DeleteMetadata. Intended for
 	// pruning orphaned refs whose branches no longer exist.
 	DeleteMetadataRef(ctx context.Context, branchName string) error
+	// DeleteMetadataRefsBatch deletes many branches' metadata refs in a single
+	// atomic git call. Same use case as DeleteMetadataRef, batched for callers
+	// pruning more than one orphaned ref at a time.
+	DeleteMetadataRefsBatch(ctx context.Context, branchNames []string) error
 }
 
 // GitConfig provides access to git configuration values. Exposed so helpers


### PR DESCRIPTION
## Summary

- `stackit doctor --fix` pruned orphaned metadata refs (metadata for branches that no longer exist) one at a time, spawning a separate `git update-ref` process per orphaned branch.
- Added `Engine.DeleteMetadataRefsBatch`, which mirrors the `DeleteRefsBatch` pattern already used by `branch_mutations.go`, `branch_tracking.go`, `engine_worktree.go`, and `metadata_transport.go` for deleting multiple refs atomically in one `git update-ref --stdin` call.
- `checkStackState` now collects all orphaned branch names first and deletes them in a single batch call, instead of calling `DeleteMetadataRef` in a loop. A repo with many stale metadata refs (common after heavy branch churn) now costs one git invocation instead of N.
- Per-branch `OnCheck` reporting is preserved so `doctor --fix` output is unchanged for the user; the underlying deletion is now atomic (all-or-nothing) rather than independent per-branch attempts, consistent with how every other multi-ref delete in the codebase behaves.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] Added `TestCheckStackStatePrunesOrphanedMetadataInOneBatch`, which creates two branches, tracks them, deletes the branch heads (leaving orphaned metadata), runs `checkStackState` with `fix=true`, and asserts both are pruned and reported.
- [x] `go test ./internal/actions/doctor/...` — pass
- [x] `go test ./internal/actions/...` — pass
- [x] `go test ./internal/engine/...` — pass (aside from two pre-existing, unrelated `synctest`/lumberjack deadlock failures reproduced identically on `main` without this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WPEJkQmWhxgffxqVdRwXL

---
_Generated by [Claude Code](https://claude.ai/code/session_011WPEJkQmWhxgffxqVdRwXL)_