### PR TITLE
feat: add dashboard search and refine the layout

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,9 +1,9 @@
 # Shared dev Procfile for both `mise run dev` and `mise run dev:hosted`. The two
-# tasks differ only by STACKIT_DATABASE_URL, set at the task level in mise.toml:
-#   - `dev`        clears it → single-repo mode (discovers the cwd git repo, no
+# tasks set STACKIT_DEV_DATABASE_URL at the task level in mise.toml:
+#   - `dev`        leaves it empty -> single-repo mode (discovers the cwd git repo, no
 #                  picker; the web UI opens that repo directly).
-#   - `dev:hosted` keeps the mise [env] value → DB-backed multi-tenant mode
+#   - `dev:hosted` copies STACKIT_DATABASE_URL -> DB-backed multi-tenant mode
 #                  (serves repos from the store, shows the picker; run
 #                  `mise run db:up` first).
-server: watchexec -r -e go -w apps/server -w internal -w api -- go run ./apps/server --port 8080
-web: NEXT_PUBLIC_API_URL=http://localhost:8080 pnpm --filter @stackit/web dev
+server: watchexec -r -e go -w apps/server -w internal -w api -- go run ./apps/server --port 8080 --database-url="${STACKIT_DEV_DATABASE_URL:-}"
+web: NEXT_PUBLIC_API_URL= pnpm --filter @stackit/web dev --hostname 0.0.0.0 --port 3000

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import { PHASE_PRODUCTION_BUILD } from "next/constants";
+import { hostname, networkInterfaces } from "node:os";
 
 // `output: "export"` emits a static SPA that the Go server embeds and serves
 // (with an index.html fallback for deep links). It is only correct for the
@@ -10,4 +11,22 @@ import { PHASE_PRODUCTION_BUILD } from "next/constants";
 // dev server where the optional catch-all handles every path.
 export default (phase: string): NextConfig => ({
   output: phase === PHASE_PRODUCTION_BUILD ? "export" : undefined,
+  allowedDevOrigins: [
+    hostname(),
+    ...(process.env.STACKIT_DEV_HOSTNAMES ?? "")
+      .split(",")
+      .map((host) => host.trim())
+      .filter(Boolean),
+    ...Object.values(networkInterfaces()).flatMap((addresses) =>
+      (addresses ?? []).map(({ address }) => address),
+    ),
+  ],
+  // Keep browser requests on the dev host, even when the browser is on
+  // another machine. The Go backend continues listening on loopback.
+  ...(phase !== PHASE_PRODUCTION_BUILD && {
+    rewrites: async () => [
+      { source: "/api/:path*", destination: "http://127.0.0.1:8080/api/:path*" },
+      { source: "/auth/:path*", destination: "http://127.0.0.1:8080/auth/:path*" },
+    ],
+  }),
 });

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
       >
         <ThemeProvider>
           <TooltipProvider>{children}</TooltipProvider>

--- a/apps/web/src/components/branch-detail/detail-empty-state.tsx
+++ b/apps/web/src/components/branch-detail/detail-empty-state.tsx
@@ -2,10 +2,13 @@ import { GitBranch } from "lucide-react";
 
 export function DetailEmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground px-6">
-      <GitBranch className="w-8 h-8 opacity-40" />
-      <p className="text-sm text-center">
-        Select a branch or stack to view details
+    <div className="flex h-full flex-col items-center justify-center px-8 py-10 text-center">
+      <div className="mb-4 rounded-2xl border bg-muted/40 p-4 text-muted-foreground">
+        <GitBranch aria-hidden="true" className="size-6" />
+      </div>
+      <h3 className="text-sm font-medium">Explore a stack</h3>
+      <p className="mt-2 max-w-60 text-sm leading-relaxed text-muted-foreground">
+        Select a branch to review its changes, or a stack to see its pull requests and checks.
       </p>
     </div>
   );

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Layers, RefreshCw } from "lucide-react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { UserMenu } from "@/components/layout/user-menu";
 import { formatTimeAgo } from "@/lib/time";
@@ -16,42 +17,41 @@ interface HeaderProps {
 
 export function Header({ repo, lastUpdated, refresh }: HeaderProps) {
   return (
-    <header className="relative flex items-center justify-between px-4 py-2 border-b shrink-0">
-      <div className="flex items-center gap-3">
-        <Link href="/" className="font-semibold text-sm hover:text-foreground/80 transition-colors">
+    <header className="relative z-10 flex min-h-14 shrink-0 items-center justify-between gap-3 border-b bg-background px-4 sm:px-6">
+      <div className="flex min-w-0 items-center gap-3">
+        <Link href="/" className="flex shrink-0 items-center gap-2 rounded-md text-sm font-semibold tracking-tight transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          <Layers aria-hidden="true" className="size-4" />
           stackit
         </Link>
         {repo && (
-          <span className="text-sm text-muted-foreground font-mono">
-            {repo.owner}/{repo.repo}
-          </span>
+          <>
+            <span aria-hidden="true" className="text-border">/</span>
+            <span className="truncate text-sm text-muted-foreground" title={`${repo.owner}/${repo.repo}`}>
+              <span className="hidden lg:inline">{repo.owner}/</span><span className="font-medium text-foreground">{repo.repo}</span>
+            </span>
+          </>
         )}
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex shrink-0 items-center gap-1.5 sm:gap-3">
         {lastUpdated && (
-          <span className="text-xs text-muted-foreground">
-            {formatTimeAgo(lastUpdated)}
+          <span className="hidden text-xs text-muted-foreground lg:inline">
+            Updated {formatTimeAgo(lastUpdated)}
           </span>
         )}
         <ThemeToggle />
         {refresh && (
           <button
+            type="button"
             onClick={refresh}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            aria-label="Refresh repository"
+            className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             title="Refresh"
           >
-            &#x21BB;
+            <RefreshCw aria-hidden="true" className="size-3.5" />
           </button>
         )}
         <UserMenu />
       </div>
-      {/* Animated gradient accent bar */}
-      <div
-        className="absolute bottom-0 left-0 right-0 h-0.5 animate-gradient-shift"
-        style={{
-          background: "linear-gradient(90deg, var(--gradient-start), var(--gradient-mid), var(--gradient-end), var(--gradient-start))",
-        }}
-      />
     </header>
   );
 }

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -54,7 +54,7 @@ export function UserMenu() {
         <span className="flex h-6 w-6 items-center justify-center rounded-full bg-foreground text-xs font-medium text-background">
           {initial}
         </span>
-        <span className="max-w-[14ch] truncate">{user.login}</span>
+        <span className="sr-only sm:not-sr-only sm:max-w-[14ch] sm:truncate">{user.login}</span>
       </button>
 
       {open && (

--- a/apps/web/src/components/repo-picker/__tests__/repo-view.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/repo-view.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { StackDetail } from "@/lib/api";
+import { RepoView } from "@/components/repo-picker/repo-view";
+
+const { useRepo } = vi.hoisted(() => ({ useRepo: vi.fn() }));
+vi.mock("@/components/providers/repo-provider", () => ({ useRepo }));
+vi.mock("next/dynamic", () => ({ default: () => () => null }));
+vi.mock("@/components/layout/header", () => ({ Header: () => null }));
+vi.mock("@/components/layout/event-feed", () => ({ EventFeed: () => null }));
+vi.mock("@/components/ui/background-mesh", () => ({ BackgroundMesh: () => null }));
+vi.mock("@/components/branch-detail/branch-detail", () => ({ BranchDetail: () => null }));
+vi.mock("@/components/recently-merged/recently-merged", () => ({
+  RecentlyMerged: () => <div>Commit history</div>,
+}));
+vi.mock("@/components/swimlane/owner-swimlane", () => ({
+  OwnerSwimlane: ({ stacks, onSelectStack }: {
+    stacks: StackDetail[];
+    onSelectStack: (stack: StackDetail) => void;
+  }) => stacks.map((stack) => (
+    <button key={stack.rootBranch} onClick={() => onSelectStack(stack)}>
+      {stack.title}
+    </button>
+  )),
+}));
+vi.mock("@/components/branch-detail/stack-detail", () => ({
+  StackDetailPanel: ({ stack }: { stack: StackDetail }) => <div>Selected: {stack.title}</div>,
+}));
+
+const stacks: StackDetail[] = [
+  {
+    rootBranch: "feat/login", title: "Account access", owner: "alice",
+    status: "pending", branchCount: 0, prCount: 0, isCurrent: false, branches: [],
+  },
+  {
+    rootBranch: "fix/cache", title: "Cache refresh", owner: "bob",
+    status: "shippable", branchCount: 0, prCount: 0, isCurrent: false, branches: [],
+  },
+];
+
+beforeEach(() => {
+  window.history.replaceState({}, "", "/example/repo");
+  useRepo.mockReturnValue({
+    repo: { owner: "example", repo: "repo", trunk: "main", currentUser: "alice" },
+    stackDetails: stacks, loading: false, error: null, refresh: vi.fn(),
+  });
+});
+
+describe("RepoView search", () => {
+  it("filters swimlanes and restores stacks after clearing an unmatched search", () => {
+    render(<RepoView />);
+    const search = screen.getByRole("searchbox", { name: "Search stacks" });
+    fireEvent.change(search, { target: { value: "@bob" } });
+    expect(screen.queryByRole("button", { name: "Account access" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cache refresh" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("1 of 2 stacks");
+
+    fireEvent.change(search, { target: { value: "missing" } });
+    expect(screen.getByText("No stacks match your search.")).toBeInTheDocument();
+    expect(screen.getByText("Commit history")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(search).toHaveValue("");
+    expect(screen.getByRole("status")).toHaveTextContent("2 stacks");
+    expect(screen.getByRole("button", { name: "Account access" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cache refresh" })).toBeInTheDocument();
+  });
+
+  it("keeps selected stack details open when search hides its swimlane", () => {
+    render(<RepoView />);
+    fireEvent.click(screen.getByRole("button", { name: "Account access" }));
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "cache" } });
+    expect(screen.getByText("Selected: Account access")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Account access" })).not.toBeInTheDocument();
+  });
+
+  it("clears search with Escape while retaining keyboard focus", () => {
+    render(<RepoView />);
+    const search = screen.getByRole("searchbox");
+    search.focus();
+    fireEvent.change(search, { target: { value: "cache" } });
+    fireEvent.keyDown(search, { key: "Escape" });
+    expect(search).toHaveValue("");
+    expect(search).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Account access" })).toBeInTheDocument();
+  });
+
+  it("returns to the overview when details are closed", () => {
+    render(<RepoView />);
+    fireEvent.click(screen.getByRole("button", { name: "Account access" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close details" }));
+    expect(screen.queryByText("Selected: Account access")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/repo-picker/repo-view.tsx
+++ b/apps/web/src/components/repo-picker/repo-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import dynamic from "next/dynamic";
+import { ChevronDown, GitBranch, SearchX, X } from "lucide-react";
 import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane } from "@/components/swimlane/owner-swimlane";
 import { getLastActiveDate } from "@/lib/swimlane-grouping";
@@ -15,6 +16,9 @@ import { BackgroundMesh } from "@/components/ui/background-mesh";
 import { SkeletonSwimlane } from "@/components/ui/skeleton-shimmer";
 import { useUrlSelection } from "@/hooks/use-url-selection";
 import { groupStacksByOwner } from "@/lib/swimlane-grouping";
+import { filterStacks } from "@/lib/stack-search";
+import { StackToolbar } from "@/components/swimlane/stack-toolbar";
+import { cn } from "@/lib/utils";
 
 const BranchDiffWorkspace = dynamic(
   () =>
@@ -53,9 +57,14 @@ export function RepoView() {
     handleStackBranchSelect,
   } = useUrlSelection(stackDetails);
 
+  const [searchQuery, setSearchQuery] = useState("");
+  const filteredStacks = useMemo(
+    () => filterStacks(stackDetails, searchQuery),
+    [stackDetails, searchQuery]
+  );
   const { yourStacks, otherOwners } = useMemo(
-    () => groupStacksByOwner(stackDetails, repo?.currentUser),
-    [stackDetails, repo?.currentUser]
+    () => groupStacksByOwner(filteredStacks, repo?.currentUser),
+    [filteredStacks, repo?.currentUser]
   );
 
   const [recentCommitsPreference, setRecentCommitsPreference] = useState(true);
@@ -65,6 +74,24 @@ export function RepoView() {
   const stacksAndHistoryContent =
     stackDetails.length > 0 ? (
       <div className="flex flex-col justify-end min-h-full">
+        {filteredStacks.length === 0 && (
+          <div className="flex flex-1 flex-col items-center justify-center px-6 py-12 text-center">
+            <div className="mb-4 rounded-2xl border bg-background p-3 text-muted-foreground shadow-sm">
+              <SearchX aria-hidden="true" className="size-5" />
+            </div>
+            <h2 className="text-sm font-medium">No stacks match your search.</h2>
+            <p className="mt-1 max-w-xs text-sm text-muted-foreground">
+              Try a branch name, PR number, or owner.
+            </p>
+            <button
+              type="button"
+              onClick={() => setSearchQuery("")}
+              className="mt-4 rounded-lg border bg-background px-3 py-2 text-sm font-medium shadow-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Show all stacks
+            </button>
+          </div>
+        )}
         {/* Swimlanes: only this area scrolls horizontally */}
         <div className="overflow-x-auto">
           <div className="flex items-end gap-6 p-6 pb-4 min-w-max">
@@ -107,10 +134,16 @@ export function RepoView() {
             </span>
           ) : (
             <button
+              type="button"
+              aria-expanded={showRecentCommits}
+              aria-controls="recent-trunk-commits"
               onClick={() => setRecentCommitsPreference((prev) => !prev)}
-              className="text-xs font-mono text-muted-foreground/70 px-2 hover:text-muted-foreground transition-colors cursor-pointer"
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              {repo?.trunk}
+              <GitBranch aria-hidden="true" className="size-3.5" />
+              <span className="font-mono">{repo?.trunk}</span>
+              <span>Recent commits</span>
+              <ChevronDown aria-hidden="true" className={cn("size-3.5 transition-transform", !showRecentCommits && "-rotate-90")} />
             </button>
           )}
           <div className="flex-1 h-[2px] bg-gradient-to-l from-transparent via-muted-foreground/30 to-muted-foreground/30" />
@@ -118,6 +151,8 @@ export function RepoView() {
 
         {/* Recent trunk commits */}
         <div
+          id="recent-trunk-commits"
+          inert={!showRecentCommits}
           className="grid transition-[grid-template-rows,opacity] duration-300 ease-in-out"
           style={{
             gridTemplateRows: showRecentCommits ? "1fr" : "0fr",
@@ -130,8 +165,14 @@ export function RepoView() {
         </div>
       </div>
     ) : (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        No stacks found
+      <div className="flex h-full flex-col items-center justify-center px-6 py-12 text-center">
+        <div className="mb-4 rounded-2xl border bg-background p-3 text-muted-foreground shadow-sm">
+          <GitBranch aria-hidden="true" className="size-5" />
+        </div>
+        <h2 className="text-base font-medium">No stacks yet</h2>
+        <p className="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
+          Tracked branches will appear here, grouped into stacks by owner.
+        </p>
       </div>
     );
 
@@ -163,8 +204,7 @@ export function RepoView() {
   }
 
   return (
-    <div className="flex flex-col h-screen">
-      <BackgroundMesh />
+    <div className="flex h-dvh flex-col bg-muted/20">
       <Header repo={repo ?? null} lastUpdated={lastUpdated ?? null} refresh={refresh} />
 
       {/* Main content: stacks area + detail panel.
@@ -174,6 +214,12 @@ export function RepoView() {
           so no data renders. */}
       <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
         <div className="flex flex-1 flex-col overflow-hidden min-h-0 min-w-0">
+          <StackToolbar
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+            matchingCount={filteredStacks.length}
+            totalCount={stackDetails.length}
+          />
           {branchOverlayMode && selectedBranch && selectedBranchStack ? (
             <>
               <div className="min-h-0 flex-1 overflow-hidden border-b">
@@ -197,7 +243,23 @@ export function RepoView() {
             mobile (bounded height), beside them on desktop (fixed width). */}
         <div className="flex shrink-0 flex-col border-t md:flex-row md:border-t-0">
           <div aria-hidden className="hidden w-px shrink-0 bg-border md:block" />
-          <div className="flex h-[45vh] w-full shrink-0 flex-col overflow-hidden md:h-auto md:w-[480px]">
+          <aside aria-label="Stack details and activity" className={cn(
+            "flex w-full shrink-0 flex-col overflow-hidden bg-background md:h-auto md:w-[360px] xl:w-[420px]",
+            hasSelection ? "h-[45dvh]" : "max-h-[25dvh] md:max-h-none"
+          )}>
+            <div className={cn("shrink-0 items-center justify-between border-b px-4 py-3", hasSelection ? "flex" : "hidden md:flex")}>
+              <h2 className="text-sm font-medium">{hasSelection ? "Stack details" : "Overview"}</h2>
+              {hasSelection && (
+                <button
+                  type="button"
+                  onClick={handleClearSelection}
+                  aria-label="Close details"
+                  className="flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <X aria-hidden="true" className="size-4" />
+                </button>
+              )}
+            </div>
             {branchOverlayMode && selectedBranchStack ? (
               <div className="flex-1 overflow-auto p-4">
                 <StackDetailPanel
@@ -223,7 +285,7 @@ export function RepoView() {
                 )}
               </div>
             ) : (
-              <div className="flex-1">
+              <div className="hidden min-h-0 flex-1 md:block">
                 <DetailEmptyState />
               </div>
             )}
@@ -235,7 +297,7 @@ export function RepoView() {
                 </div>
               </>
             )}
-          </div>
+          </aside>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/swimlane/stack-toolbar.tsx
+++ b/apps/web/src/components/swimlane/stack-toolbar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useRef } from "react";
+import { Search, X } from "lucide-react";
+
+interface StackToolbarProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  matchingCount: number;
+  totalCount: number;
+}
+
+export function StackToolbar({ query, onQueryChange, matchingCount, totalCount }: StackToolbarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const clearSearch = () => {
+    onQueryChange("");
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="shrink-0 border-b bg-background px-4 py-4 sm:px-6">
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-semibold tracking-tight">Stacks</h1>
+          <span role="status" className="rounded-full bg-muted px-2.5 py-1 text-xs tabular-nums text-muted-foreground">
+            {query.trim() ? `${matchingCount} of ${totalCount}` : totalCount}{" "}
+            {totalCount === 1 ? "stack" : "stacks"}
+          </span>
+        </div>
+        <div role="search" aria-label="Stacks" className="w-full xl:max-w-sm">
+          <label htmlFor="stack-search" className="sr-only">Search stacks</label>
+          <div className="flex h-10 items-center gap-2 rounded-lg border bg-muted/30 px-3 transition-colors focus-within:border-ring focus-within:bg-background focus-within:ring-2 focus-within:ring-ring/20">
+            <Search aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              id="stack-search"
+              type="search"
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape" && query) {
+                  event.preventDefault();
+                  clearSearch();
+                }
+              }}
+              placeholder="Branch, PR, or @owner…"
+              className="h-full min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:appearance-none"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                aria-label="Clear search"
+                className="-mr-1 flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X aria-hidden="true" className="size-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/theme-toggle.tsx
+++ b/apps/web/src/components/ui/theme-toggle.tsx
@@ -20,7 +20,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={next}
-      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       title={`Theme: ${label}. Click to cycle.`}
     >
       <Icon className="w-3.5 h-3.5" />

--- a/apps/web/src/lib/__tests__/stack-search.test.ts
+++ b/apps/web/src/lib/__tests__/stack-search.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { BranchResponse, StackDetail } from "@/lib/api";
+import { filterStacks } from "@/lib/stack-search";
+
+function branch(name: string): BranchResponse {
+  return {
+    name, depth: 0, isCurrent: false, needsRestack: false,
+    isLocked: false, isFrozen: false, revision: "abc123",
+    commitDate: "2026-09-08", commitAuthor: "Alice", commitCount: 1,
+    linesAdded: 0, linesDeleted: 0,
+  };
+}
+
+const stacks: StackDetail[] = [
+  {
+    rootBranch: "feat/auth", title: "Account access", owner: "alice", scope: "web",
+    status: "pending", branchCount: 2, prCount: 1, isCurrent: false,
+    branches: [
+      branch("feat/auth"),
+      {
+        ...branch("feat/login"), parent: "feat/auth",
+        pr: {
+          number: 123, title: "Add sign in", state: "OPEN", isDraft: false,
+          url: "https://github.com/example/repo/pull/123", base: "feat/auth",
+        },
+      },
+    ],
+  },
+  {
+    rootBranch: "fix/cache", title: "Cache refresh", status: "shippable",
+    branchCount: 1, prCount: 0, isCurrent: true, branches: [branch("fix/cache")],
+  },
+];
+
+describe("filterStacks", () => {
+  it.each(["", "  \n  "])("shows all stacks for a blank query %j", (query) => {
+    expect(filterStacks(stacks, query)).toEqual(stacks);
+  });
+
+  it.each(["feat/login", "ACCOUNT", "sign in", "123", "#123", "ALICE", "@alice", "web"])(
+    "finds stacks by %j without removing parent branches", (query) => {
+      expect(filterStacks(stacks, query)).toEqual([stacks[0]]);
+      expect(filterStacks(stacks, query)[0].branches).toHaveLength(2);
+    }
+  );
+
+  it("matches multiple terms across stack and branch metadata", () => {
+    expect(filterStacks(stacks, "  alice  sign  #123 ")).toEqual([stacks[0]]);
+    expect(filterStacks(stacks, "alice cache")).toEqual([]);
+  });
+
+  it("handles stacks without owners or PRs", () => {
+    expect(filterStacks(stacks, "cache")).toEqual([stacks[1]]);
+    expect(filterStacks(stacks, "missing")).toEqual([]);
+    expect(filterStacks([], "cache")).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,8 +2,8 @@
 
 // Empty default = same-origin requests. The embedded production build is
 // served from the Go server itself, so relative URLs hit the right host
-// without baking it in at build time. Set NEXT_PUBLIC_API_URL when running
-// `next dev` against a separate Go server on another port.
+// without baking it in at build time. Next dev proxies these same relative
+// URLs to the local Go server. NEXT_PUBLIC_API_URL overrides that routing.
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 // CSRF_HEADER must be sent on every non-safe request. The server doesn't

--- a/apps/web/src/lib/stack-search.ts
+++ b/apps/web/src/lib/stack-search.ts
@@ -1,0 +1,23 @@
+import type { StackDetail } from "@/lib/api";
+
+// Keep whole stacks intact so matching branches retain their parent context.
+export function filterStacks(stacks: StackDetail[], query: string): StackDetail[] {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return stacks;
+
+  return stacks.filter((stack) => {
+    const fields = [
+      stack.rootBranch,
+      stack.title,
+      stack.owner ? `@${stack.owner}` : undefined,
+      stack.scope,
+      ...stack.branches.flatMap((branch) => [
+        branch.name,
+        branch.pr?.title,
+        branch.pr ? `#${branch.pr.number}` : undefined,
+      ]),
+    ].filter((field): field is string => Boolean(field));
+    const searchable = fields.join(" ").toLowerCase();
+    return terms.every((term) => searchable.includes(term));
+  });
+}

--- a/docs/web.md
+++ b/docs/web.md
@@ -98,12 +98,19 @@ layout.tsx
         │   │   └── ...
         │   ├── TrunkLine (divider)
         │   └── RecentlyMerged (trunk commit history)
-        └── RightPanel (400px fixed)
+        └── RightPanel (360px, 420px on wide screens)
             ├── BranchDetail / StackDetailPanel
             └── EventFeed
 ```
 
 ## Data Flow
+
+The dashboard toolbar searches stack titles, scopes, branch names, PR titles or
+numbers, and owners (including `#123` and `@owner`). Matching is case-insensitive;
+multiple words must all match within a stack. Results retain each complete stack
+and do not dismiss selected details. Clear the query with the search field's
+clear button or Escape. On mobile, the empty detail panel is hidden to leave
+more room for stacks; selecting a stack opens the panel below the board.
 
 1. **RepoProvider** calls `fetchView(repoRef)` on mount → GET `/api/v1/repos/{owner}/{repo}/view`
 2. Response contains: repo metadata, all stack details, recently merged commits
@@ -147,9 +154,10 @@ GitHub coordinates (no remote) and so can't be addressed in the path UI.
 
 The API base URL is configured via `NEXT_PUBLIC_API_URL`. Default is empty
 (same-origin) so the embedded production build, served by the Go binary,
-hits whatever host the page came from. Set it explicitly when running
-`next dev` on `:3000` against a Go server on a different port — e.g.
-`NEXT_PUBLIC_API_URL=http://localhost:8080` in `apps/web/.env.local`.
+hits whatever host the page came from. Next dev proxies `/api/*` and `/auth/*`
+to the Go server at `127.0.0.1:8080`, so remote browsers use the same origin
+as the dashboard. Set `NEXT_PUBLIC_API_URL` only to override that routing;
+`mise run dev` explicitly clears it.
 
 ### Type Contracts
 
@@ -216,18 +224,40 @@ mise run web:dev
 go run ./apps/server --port 8080
 ```
 
-`dev` and `dev:hosted` share `Procfile.dev`; they differ only in whether
-`STACKIT_DATABASE_URL` is set (the `dev` task clears it). When the server
+`dev` and `dev:hosted` share `Procfile.dev`. They pass an explicit
+`--database-url` through `STACKIT_DEV_DATABASE_URL`: empty for `dev`, or copied
+from `STACKIT_DATABASE_URL` for `dev:hosted`. This keeps local mode independent
+of environment variables reloaded by child shells. When the server
 reports `singleRepo` via `/api/v1/config`, the web client skips the picker
 and navigates straight to the sole repo.
 
-The web dev server runs at `http://localhost:3000` and proxies API requests to `http://localhost:8080`.
+The web dev server listens on port 3000 on all interfaces and proxies API
+requests to the Go server on loopback port 8080. It allows Next.js dev assets
+from the machine hostname and interface addresses. Add custom hostnames in
+`apps/web/.env.local` (gitignored), which Next.js loads automatically:
+
+```dotenv
+STACKIT_DEV_HOSTNAMES=workstation.internal,stackit.workstation.internal
+```
+
+Use comma-separated hostnames without schemes or ports. Restart `mise run dev`
+after changing this setting. Use this on a trusted development network: the proxy
+provides access to the local API, which is anonymous by default.
+
+To use `http://stackit.workstation.internal:3000`, point that hostname at the
+dev box's IP in your local DNS (an A record, or a CNAME to the box's hostname).
+Alternatively, add an entry to the hosts file on the machine running your
+browser, mapping the dev box's IP to your custom hostname. The name must resolve
+on the browser's machine, not just on the dev box. To omit `:3000`, configure
+a reverse proxy on port 80 for that hostname, forwarding to `127.0.0.1:3000`
+with WebSocket support for hot reload.
 
 ### Environment Variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `NEXT_PUBLIC_API_URL` | `http://localhost:8080` | API server URL |
+| `NEXT_PUBLIC_API_URL` | Empty (same origin) | Optional API server URL override |
+| `STACKIT_DEV_HOSTNAMES` | Empty | Additional comma-separated hostnames allowed to load dev assets; set in `apps/web/.env.local` |
 
 ### Build & Deploy
 

--- a/mise.toml
+++ b/mise.toml
@@ -289,14 +289,14 @@ run = """
 
 [tasks.dev]
 description = "Run server + web dev servers (local single-repo mode: serves the current git repo, no picker)"
-# Clear STACKIT_DATABASE_URL (set in [env]) so the server takes the single-repo
-# cwd shortcut instead of the DB-backed multi-tenant path. Both dev tasks share
-# Procfile.dev; this inline clear is the only difference from dev:hosted.
-run = "STACKIT_DATABASE_URL= overmind start -f Procfile.dev"
+# Pass the database choice through a dedicated variable: child shells can
+# reactivate mise and restore STACKIT_DATABASE_URL from [env]. Procfile.dev
+# uses an explicit server flag so that cannot switch local dev into hosted mode.
+run = "STACKIT_DEV_DATABASE_URL= overmind start -f Procfile.dev"
 
 [tasks."dev:hosted"]
 description = "Run server + web dev servers in DB-backed multi-tenant mode (the hosted model; run db:up first)"
-run = "overmind start -f Procfile.dev"
+run = 'STACKIT_DEV_DATABASE_URL="$STACKIT_DATABASE_URL" overmind start -f Procfile.dev'
 
 [tasks."dev:stop"]
 description = "Stop the overmind dev process group and clean up orphaned backend listeners"


### PR DESCRIPTION
Finding a branch in the dashboard currently requires scanning owner swimlanes. Add search by branch name, stack title, scope, owner (including `@alice`), and PR title or number (including `#123`). Queries match without regard to case and can combine multiple terms.

Matching stacks retain all their branches so parent relationships remain visible. A dedicated Stacks toolbar shows the matching count and provides a clear button and Escape support, while selected details remain open during filtering.

Refine the dashboard with a quieter header and background, consistent controls, more helpful empty states, a labeled recent-commits toggle, and a close action for details. Narrower desktop panels and hiding the empty panel on mobile leave more room for stacks. Apply the existing Geist font to page text.

Validation: all 101 web tests, TypeScript checking, ESLint, and `mise run test` pass. ESLint reports one existing warning in `next.config.ts`. The production static export passes with `pnpm --filter @stackit/web build --webpack`; the default Turbopack build was blocked by local worker port restrictions in this environment. Chromium checks against the production export with fixture API data cover desktop and dark-mode rendering, empty results, mobile details, search clearing and focus, closing details, and no page overflow at 320px, 390px, and 768px.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1735** 👈
  * **PR #1736**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->