### PR TITLE
refactor: drop unused context params from internal helper funcs

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -85,7 +85,7 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 	splog.Info("✅ Created consolidation branch: %s", consolidationBranch)
 
 	// Lock individual PRs and update them with a notice
-	if err := c.lockAndNotifyIndividualPRs(ctx, consolidationBranch); err != nil {
+	if err := c.lockAndNotifyIndividualPRs(consolidationBranch); err != nil {
 		splog.Warn("Failed to lock and notify individual PRs: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 			c.consolidationUser = userName
 		}
 
-		c.postMergeCleanup(ctx)
+		c.postMergeCleanup()
 
 		splog.Info("🎉 Stack consolidation merge completed successfully!")
 	} else {
@@ -264,7 +264,7 @@ func (c *ConsolidateMergeExecutor) waitForConsolidationMerge(ctx context.Context
 	return waiter.WaitAndMerge(ctx, branchName, pr, expectChecks, mergeOpts)
 }
 
-func (c *ConsolidateMergeExecutor) postMergeCleanup(_ context.Context) {
+func (c *ConsolidateMergeExecutor) postMergeCleanup() {
 	c.ctx.Output.Info("🧹 Updating individual PRs...")
 
 	c.updateIndividualPRs()
@@ -288,7 +288,7 @@ func (c *ConsolidateMergeExecutor) updateIndividualPRs() {
 	cleaner.LogResult(result)
 }
 
-func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context, consolidationBranch string) error {
+func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(consolidationBranch string) error {
 	splog := c.ctx.Output
 	splog.Info("🔒 Locking individual PRs and updating status...")
 

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -90,7 +90,7 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 
 	// Handle interactive rebase separately
 	if opts.InteractiveRebase {
-		return interactiveRebaseAction(ctx, opts)
+		return interactiveRebaseAction(ctx)
 	}
 
 	// Check if rebase is in progress (only for non-interactive mode)
@@ -277,7 +277,7 @@ func ensureModifyTargetNotCheckedOutElsewhere(ctx context.Context, eng engine.En
 }
 
 // interactiveRebaseAction performs an interactive rebase on the branch's commits
-func interactiveRebaseAction(ctx *app.Context, _ ModifyOptions) error {
+func interactiveRebaseAction(ctx *app.Context) error {
 	eng := ctx.Engine
 	out := ctx.Output
 	gctx := ctx.Context


### PR DESCRIPTION
## Summary

- `interactiveRebaseAction` (internal/actions/modify.go) ignored its `ModifyOptions` parameter entirely.
- `ConsolidateMergeExecutor.postMergeCleanup` and `.lockAndNotifyIndividualPRs` (internal/actions/merge/consolidate.go) both ignored their `context.Context` parameter.

None of these three are interface implementations (verified no interface/handler type requires the extra parameter, and each has a single call site in the same file), so per `.claude/rules/code-style.md` ("Remove unused parameters entirely (don't use `_`)") the unused parameters are dropped rather than kept as `_`.

This is a pure signature cleanup with no behavior change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./internal/actions/... ./internal/actions/merge/...` (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4LVXtnXxKo3HmPmn7j3Uo

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4LVXtnXxKo3HmPmn7j3Uo)_