### PR TITLE
fix(tui): mark split wizard canceled on ctrl+c/q at type selection

### DIFF
--- a/internal/tui/components/split/model.go
+++ b/internal/tui/components/split/model.go
@@ -145,8 +145,9 @@ func (m *Model) Init() tea.Cmd {
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Handle common messages first
 	if handled, cmd := m.HandleCommonMsg(msg); handled {
-		// Don't quit on ctrl+c/q, instead mark as canceled
-		if m.Done {
+		// HandleCommonMsg also reports "handled" for spinner ticks; only a
+		// ctrl+c/q keypress should be treated as a cancel.
+		if _, isKey := msg.(tea.KeyPressMsg); isKey {
 			m.state = StateCanceled
 			m.result.Canceled = true
 			return m, tea.Quit

--- a/internal/tui/components/split/model_test.go
+++ b/internal/tui/components/split/model_test.go
@@ -1,0 +1,48 @@
+package split
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModel_Update_KeyMsg_Quit_MarksCanceled(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		msg  tea.Msg
+	}{
+		{"ctrl+c cancels", tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}},
+		{"q cancels", tea.KeyPressMsg{Code: 'q', Text: "q"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			model := NewModel(Config{AvailableTypes: []TypeChoice{{Style: StyleHunk, Available: true}}})
+			model.Init()
+
+			newModel, cmd := model.Update(tt.msg)
+			m := newModel.(*Model)
+
+			assert.NotNil(t, cmd, "should return quit command")
+			assert.True(t, m.GetResult().Canceled, "result should be marked canceled")
+			assert.Equal(t, StateCanceled, m.state)
+		})
+	}
+}
+
+func TestModel_Update_SpinnerTickMsg_DoesNotCancel(t *testing.T) {
+	t.Parallel()
+	model := NewModel(Config{AvailableTypes: []TypeChoice{{Style: StyleHunk, Available: true}}})
+	model.Init()
+
+	newModel, cmd := model.Update(spinner.TickMsg{})
+	m := newModel.(*Model)
+
+	assert.NotNil(t, cmd, "should return spinner tick command")
+	assert.False(t, m.GetResult().Canceled, "spinner tick should not cancel the wizard")
+	assert.Equal(t, StateSelectingType, m.state)
+}


### PR DESCRIPTION
## Summary

- `BaseModel.HandleCommonMsg` reports `handled=true` for both a ctrl+c/q keypress *and* a `spinner.TickMsg` pass-through. The split wizard's `Update` guarded the cancel logic on `m.Done`, a `BaseModel` field that nothing in the split package ever sets — so it was always `false`, and both cases fell through to a bare `return m, cmd`.
- For a plain `q`/ctrl+c keypress that meant `tea.Quit` fired without ever setting `state = StateCanceled` / `result.Canceled = true`, unlike every other cancellation path in this file (6 other call sites already follow that pattern).
- Concretely: pressing `q` on the split wizard's type-selection screen (`PromptSplitType`, the live prompt used when a branch has more than one commit and no `--by-commit`/`--by-hunk`/`--by-file` flag was given) returns `Canceled: false`, `Error: nil`, `Style: ""`. `internal/cli/branch/split_handlers.go` then treats that as a valid (empty) selection instead of `errors.ErrCanceled`, and `internal/actions/split/split.go` proceeds into `handler.Start(...)`/`eng.TakeSnapshot(...)` with `style = ""` instead of stopping.
- Fix: check the message type instead of the dead `m.Done` field, so only an actual keypress marks the result canceled; a spinner tick still falls through to `return m, cmd` as before.

## Test plan

- [x] Added `internal/tui/components/split/model_test.go` covering: ctrl+c/q mark the result canceled and return `tea.Quit`; a spinner tick does not cancel. Verified the new test fails against the old code and passes with the fix.
- [x] `go build ./...`
- [x] `go test ./internal/tui/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuZukykPjSJL2QUDPQuw7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuZukykPjSJL2QUDPQuw7e)_