### PR TITLE
perf(dashboard): batch branch stats/commits once across all shippable stacks

### DIFF
--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -395,6 +395,24 @@ func (m *shippableModel) rebuildCache() {
 	}
 
 	// Precompute titles, descriptions, and annotations for all stacks
+	//
+	// Branch stats and commits are batched once across every stack's branches
+	// (not per stack) to avoid N separate git subprocess round-trips for N
+	// shippable stacks. This runs on every refresh and on the auto-refresh
+	// timer, so the savings compound. The view renders with
+	// ShowCommitMessages, so resolve commit messages once via BatchCommits and
+	// skip the per-branch GetAllCommits inside GetBranchAnnotation.
+	allBranches := engine.Branches{}
+	for _, stack := range m.stacks {
+		for _, branchName := range stack.Stack.AllBranches {
+			if branch := m.engine.GetBranch(branchName); branch.GetName() != "" {
+				allBranches = allBranches.Append(branch)
+			}
+		}
+	}
+	stats := m.engine.BatchBranchStats(allBranches)
+	commits := m.engine.BatchCommits(allBranches, engine.CommitFormatReadable)
+
 	for _, stack := range m.stacks {
 		rootBranch := stack.RootBranch()
 
@@ -415,20 +433,11 @@ func (m *shippableModel) rebuildCache() {
 			}
 		}
 
-		// Compute annotations for all branches in the stack, reading their
-		// git-computed stats from batched value maps rather than per branch (this
-		// runs on every refresh and on the auto-refresh timer). The view renders
-		// with ShowCommitMessages, so resolve commit messages once via BatchCommits
-		// and skip the per-branch GetAllCommits inside GetBranchAnnotation.
-		stackBranches := engine.Branches{}
 		for _, branchName := range stack.Stack.AllBranches {
-			if branch := m.engine.GetBranch(branchName); branch.GetName() != "" {
-				stackBranches = stackBranches.Append(branch)
+			branch := m.engine.GetBranch(branchName)
+			if branch.GetName() == "" {
+				continue
 			}
-		}
-		stats := m.engine.BatchBranchStats(stackBranches)
-		commits := m.engine.BatchCommits(stackBranches, engine.CommitFormatReadable)
-		for _, branch := range stackBranches {
 			name := branch.GetName()
 			ann := tui.GetBranchAnnotation(m.engine, branch, stats[name], tui.AnnotationOptions{SkipCommitMessages: true})
 			if msgs := commits[name]; msgs != nil {


### PR DESCRIPTION

rebuildCache called BatchBranchStats/BatchCommits once per stack, so a
repo with N shippable stacks paid N pairs of git subprocess round-trips
instead of one. This runs on every dashboard refresh and on the
auto-refresh timer, so the cost compounds. Collect branches across all
stacks first and batch once, mirroring the same fix already applied to
the /view and /stacks API handlers.

---
_Generated by [Claude Code](https://claude.ai/code/session_014pLG8L3Pvmq9Cw8WLSvkS6)_