### PR TITLE
fix: clean test binaries from external Go caches

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -165,13 +165,17 @@ description = "Run integration tests only with compact, actionable output"
 run = "scripts/check-quiet.sh test integration"
 
 [tasks.clean]
-description = "Clean built binaries, shims, and test artifacts"
+description = "Clean built binaries, shims, test artifacts, and cached test binaries"
 run = """
+  go_cache="$(go env GOCACHE)"
+  if [ -n "$go_cache" ] && [ "$go_cache" != "off" ]; then
+    rm -rf "$go_cache/stackit-test-binaries"
+  fi
   rm -f coverage.out coverage.html
   rm -rf bin/
   rm -f ./stackit ./st
   find . -type d -name "stackit-test-*" -exec rm -rf {} + 2>/dev/null || true
-  echo "Cleaned: binaries (bin/), shims (./stackit, ./st), and test artifacts"
+  echo "Cleaned: binaries (bin/), shims (./stackit, ./st), test artifacts, and cached test binaries"
 """
 
 [tasks.check]

--- a/scripts/with-test-binary.sh
+++ b/scripts/with-test-binary.sh
@@ -21,6 +21,8 @@ trap 'rm -rf "$build_dir"' EXIT
 # A content-addressed path changes when the CLI changes, but stays stable on
 # unchanged runs so Go can reuse test results. Never replace a binary being
 # used by a concurrent suite running against a different revision.
+# Old revisions are retained until `mise run clean`; run it between test suites
+# to reclaim the cache without removing binaries that a suite is still using.
 binary_id="$(git hash-object "$build_dir/stackit")"
 binary_dir="$cache_root/$binary_id"
 mkdir -p "$binary_dir"


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1742**
  * **PR #1743** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->