### PR TITLE
perf: remove quadratic work from stack graph traversal

### DIFF
--- a/internal/engine/stack_graph.go
+++ b/internal/engine/stack_graph.go
@@ -5,26 +5,6 @@ import (
 	"slices"
 )
 
-// isOnActivePath checks if branchName is on the path from trunk to current branch
-func isOnActivePath(nodes map[string]*StackNode, branchName, current string) bool {
-	if current == "" {
-		return false
-	}
-	// Walk from current up to trunk, checking if branchName is on the path
-	cur := current
-	for cur != "" {
-		if cur == branchName {
-			return true
-		}
-		node := nodes[cur]
-		if node == nil {
-			break
-		}
-		cur = node.Parent
-	}
-	return false
-}
-
 // StackNode represents a branch within a stack snapshot.
 type StackNode struct {
 	Branch   Branch
@@ -102,6 +82,20 @@ func BuildStackGraph(eng BranchReader, strategy SortStrategy, filter func(Branch
 		}
 	}
 
+	// Resolve the active path once. Walking ancestry inside every comparison
+	// makes smart sorting quadratic for deep stacks with siblings at each level.
+	activePath := make(map[string]bool)
+	if strategy == SortStrategySmart {
+		for name := current; name != "" && !activePath[name]; {
+			node := graph.nodes[name]
+			if node == nil {
+				break
+			}
+			activePath[name] = true
+			name = node.Parent
+		}
+	}
+
 	// Sort children based on strategy
 	for _, node := range graph.nodes {
 		if len(node.Children) > 1 {
@@ -110,8 +104,8 @@ func BuildStackGraph(eng BranchReader, strategy SortStrategy, filter func(Branch
 				// Smart sort: hoist the active path (current branch first) and then sort descending
 				slices.SortFunc(node.Children, func(a, b string) int {
 					// Current branch or its ancestors come first
-					aOnPath := isOnActivePath(graph.nodes, a, current)
-					bOnPath := isOnActivePath(graph.nodes, b, current)
+					aOnPath := activePath[a]
+					bOnPath := activePath[b]
 					if aOnPath && !bOnPath {
 						return -1
 					}
@@ -256,7 +250,9 @@ func (g *StackGraph) DepthGroups() []DepthGroup {
 		}
 		builder := builders[node.Depth]
 		if builder == nil {
-			builder = NewBranchesBuilder(len(g.nodes))
+			// Grow with this depth's width, not the size of the whole graph.
+			// Reserving every node at every depth uses quadratic space in a chain.
+			builder = NewBranchesBuilder(0)
 			builders[node.Depth] = builder
 		}
 		builder.Add(node.Branch)

--- a/internal/engine/stack_graph_perf_test.go
+++ b/internal/engine/stack_graph_perf_test.go
@@ -1,0 +1,117 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// graphFixture keeps graph benchmarks independent of repository I/O.
+type graphFixture struct {
+	branchReader
+	branches Branches
+	parents  map[string]string
+	current  string
+}
+
+func (f *graphFixture) AllBranches() Branches { return f.branches }
+func (f *graphFixture) Trunk() Branch         { return NewBranch("main", f) }
+func (f *graphFixture) CurrentBranch() *Branch {
+	if f.current == "" {
+		return nil
+	}
+	b := NewBranch(f.current, f)
+	return &b
+}
+func (f *graphFixture) GetParent(b Branch) *Branch {
+	name := f.parents[b.GetName()]
+	if name == "" {
+		return nil
+	}
+	parent := NewBranch(name, f)
+	return &parent
+}
+
+func newGraphFixture(depth int, siblings bool) *graphFixture {
+	f := &graphFixture{parents: make(map[string]string)}
+	f.branches = append(f.branches, f.Trunk())
+	parent := "main"
+	for i := range depth {
+		name := fmt.Sprintf("branch-%04d", i)
+		f.parents[name] = parent
+		f.branches = append(f.branches, NewBranch(name, f))
+		if siblings {
+			sibling := fmt.Sprintf("sibling-%04d", i)
+			f.parents[sibling] = parent
+			f.branches = append(f.branches, NewBranch(sibling, f))
+		}
+		parent = name
+	}
+	f.current = parent
+	return f
+}
+
+func TestStackGraphSmartSortActivePath(t *testing.T) {
+	t.Parallel()
+	for _, current := range []string{"branch-0002", "", "missing"} {
+		t.Run(current, func(t *testing.T) {
+			t.Parallel()
+			f := newGraphFixture(3, true)
+			f.current = current
+			g := BuildStackGraph(f, SortStrategySmart, nil)
+			parent := "main"
+			for i := range 3 {
+				branch := fmt.Sprintf("branch-%04d", i)
+				sibling := fmt.Sprintf("sibling-%04d", i)
+				want := []string{sibling, branch}
+				if current == "branch-0002" {
+					want = []string{branch, sibling}
+				}
+				require.Equal(t, want, g.GetNode(parent).Children)
+				parent = branch
+			}
+		})
+	}
+}
+
+func TestStackGraphDeepGroups(t *testing.T) {
+	t.Parallel()
+	f := newGraphFixture(100, true)
+	g := BuildStackGraph(f, SortStrategyAlphabetical, nil)
+	groups := g.DepthGroups()
+	require.Len(t, groups, 101)
+	require.Equal(t, []string{"main"}, groups[0].Branches.Names())
+	for depth := 1; depth <= 100; depth++ {
+		require.Equal(t, depth, groups[depth].Depth)
+		require.Equal(t, []string{
+			fmt.Sprintf("branch-%04d", depth-1),
+			fmt.Sprintf("sibling-%04d", depth-1),
+		}, groups[depth].Branches.Names())
+	}
+}
+
+func BenchmarkStackGraphSmartSort(b *testing.B) {
+	for _, depth := range []int{100, 1000} {
+		b.Run(fmt.Sprint(depth), func(b *testing.B) {
+			f := newGraphFixture(depth, true)
+			b.ReportAllocs()
+			for b.Loop() {
+				BuildStackGraph(f, SortStrategySmart, nil)
+			}
+		})
+	}
+}
+
+func BenchmarkStackGraphDepthGroups(b *testing.B) {
+	for _, depth := range []int{100, 1000} {
+		b.Run(fmt.Sprint(depth), func(b *testing.B) {
+			f := newGraphFixture(depth, false)
+			g := BuildStackGraph(f, SortStrategyAlphabetical, nil)
+			b.ReportAllocs()
+			for b.Loop() {
+				g.DepthGroups()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cache active-path membership once when smart sorting, and grow depth-group
buffers with each level's width instead of reserving the whole graph per level.

Synthetic 1,000-level benchmarks reduce smart graph construction from 30.3 ms
to 1.13 ms and depth grouping allocations from 87.7 MB to 0.46 MB. Add ordering
regressions and benchmarks that isolate graph work from repository I/O.

Validation: `mise run check` passed (formatting, lint, all Go tests, web tests, typecheck, and build). Targeted graph regression tests and before/after benchmarks also passed. Benchmarks measure synthetic graph work, not end-to-end command latency.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1744** 👈
  * **PR #1745**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->
