### PR TITLE
perf: share batched diffs across branch statistics readers

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -469,14 +469,10 @@ func (d *demoGitRunner) GetDiffBetween(_ context.Context, _ git.RevRange, _ ...s
 	return "", nil
 }
 
-func (d *demoGitRunner) GetDiffNumstat(_ git.RevRange) (string, error) {
-	return "1\t1\ttest.txt", nil
-}
-
 func (d *demoGitRunner) BatchDiffNumstat(_ context.Context, ranges []git.RevRange) (map[git.RevRange]string, error) {
 	result := make(map[git.RevRange]string, len(ranges))
 	for _, rr := range ranges {
-		result[rr], _ = d.GetDiffNumstat(rr)
+		result[rr] = "1\t1\ttest.txt"
 	}
 	return result, nil
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -473,6 +473,14 @@ func (d *demoGitRunner) GetDiffNumstat(_ git.RevRange) (string, error) {
 	return "1\t1\ttest.txt", nil
 }
 
+func (d *demoGitRunner) BatchDiffNumstat(_ context.Context, ranges []git.RevRange) (map[git.RevRange]string, error) {
+	result := make(map[git.RevRange]string, len(ranges))
+	for _, rr := range ranges {
+		result[rr], _ = d.GetDiffNumstat(rr)
+	}
+	return result, nil
+}
+
 func (d *demoGitRunner) GetCommitLog(_, _ string) (string, error) {
 	return "demo commit", nil
 }

--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -91,13 +91,13 @@ func statBase(parentRev, storedBase string) string {
 // BatchDiffStats returns each non-trunk branch's additions/deletions against its
 // divergence point, keyed by branch name, resolved in one batched pass.
 func (e *engineImpl) BatchDiffStats(branches Branches) map[string]DiffStat {
-	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) DiffStat {
-		if e.IsTrunk(b) {
-			return DiffStat{}
-		}
-		added, deleted, _ := e.diffStatsBetween(git.RevRange{Base: statBase(parentRev, storedBase), Head: head})
-		return DiffStat{Added: added, Deleted: deleted}
-	})
+	ranges := e.branchStatRanges(branches)
+	stats := e.readDiffStats(context.Background(), ranges)
+	result := make(map[string]DiffStat, len(ranges))
+	for name, rr := range ranges {
+		result[name] = stats[rr].DiffStat
+	}
+	return result
 }
 
 // BatchCommits returns each non-trunk branch's formatted commits, keyed by
@@ -121,20 +121,13 @@ func (e *engineImpl) BatchCommits(branches Branches, format CommitFormat) map[st
 // keeps the file count consistent with the additions/deletions for a branch
 // whose parent has advanced since it diverged.
 func (e *engineImpl) BatchChangedFileCounts(ctx context.Context, branches Branches) map[string]int {
-	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) int {
-		if e.IsTrunk(b) {
-			return 0
-		}
-		base := statBase(parentRev, storedBase)
-		if base == "" || head == "" {
-			return 0
-		}
-		files, err := e.GetChangedFiles(ctx, git.RevRange{Base: base, Head: head})
-		if err != nil {
-			return 0
-		}
-		return len(files)
-	})
+	ranges := e.branchStatRanges(branches)
+	stats := e.readDiffStats(ctx, ranges)
+	result := make(map[string]int, len(ranges))
+	for name, rr := range ranges {
+		result[name] = stats[rr].Files
+	}
+	return result
 }
 
 // BatchBranchStats resolves the annotation stats (short SHA, commit count,
@@ -142,20 +135,22 @@ func (e *engineImpl) BatchChangedFileCounts(ctx context.Context, branches Branch
 // name. Forge status (CI, reviews) is a separate concern joined at render time,
 // not part of this.
 func (e *engineImpl) BatchBranchStats(branches Branches) map[string]BranchStat {
-	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) BranchStat {
-		st := BranchStat{}
-		st.ShortSHA = utils.ShortRevision(head, 0)
-		if e.IsTrunk(b) {
-			return st
+	ranges := e.branchStatRanges(branches)
+	diffs := e.readDiffStats(context.Background(), ranges)
+	result := make(map[string]BranchStat, len(branches))
+	values := make(map[string]*BranchStat, len(branches))
+	for name, rr := range ranges {
+		values[name] = &BranchStat{
+			ShortSHA:   utils.ShortRevision(rr.Head, 0),
+			LinesAdded: diffs[rr].Added, LinesDeleted: diffs[rr].Deleted,
 		}
-		base := statBase(parentRev, storedBase)
-		if c, err := e.commitCountBetween(git.RevRange{Base: base, Head: head}); err == nil {
-			st.CommitCount = c
-		}
-		if a, d, err := e.diffStatsBetween(git.RevRange{Base: base, Head: head}); err == nil {
-			st.LinesAdded = a
-			st.LinesDeleted = d
-		}
-		return st
+	}
+	utils.Run(branches, func(b Branch) {
+		name := b.GetName()
+		values[name].CommitCount, _ = e.commitCountBetween(ranges[name])
 	})
+	for name, stat := range values {
+		result[name] = *stat
+	}
+	return result
 }

--- a/internal/engine/diff_stats.go
+++ b/internal/engine/diff_stats.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
+)
+
+type cachedDiffStat struct {
+	DiffStat
+	Files int
+}
+
+func parseDiffStat(output string) cachedDiffStat {
+	var stat cachedDiffStat
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) != 3 {
+			continue
+		}
+		added, _ := strconv.Atoi(fields[0])
+		deleted, _ := strconv.Atoi(fields[1])
+		stat.Added += added
+		stat.Deleted += deleted
+		stat.Files++ // Binary changes and renames each count as one file too.
+	}
+	return stat
+}
+
+func (e *engineImpl) branchStatRanges(branches Branches) map[string]git.RevRange {
+	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) git.RevRange {
+		base := statBase(parentRev, storedBase)
+		if e.IsTrunk(b) {
+			base = head
+		}
+		return git.RevRange{Base: base, Head: head}
+	})
+}
+
+// readDiffStats shares numstat data between line stats and file counts. Only
+// distinct, uncached ranges go to Git; failed reads never poison the cache.
+func (e *engineImpl) readDiffStats(ctx context.Context, ranges map[string]git.RevRange) map[git.RevRange]cachedDiffStat {
+	result := make(map[git.RevRange]cachedDiffStat, len(ranges))
+	seen := make(map[git.RevRange]bool, len(ranges))
+	var missing []git.RevRange
+	for _, rr := range ranges {
+		if seen[rr] || rr.Base == rr.Head || rr.Base == "" || rr.Head == "" {
+			continue
+		}
+		seen[rr] = true
+		if stat, ok := e.diffStatsCache.Load(rr); ok {
+			result[rr] = stat.(cachedDiffStat)
+		} else {
+			missing = append(missing, rr)
+		}
+	}
+	var batch map[git.RevRange]string
+	if len(missing) > 1 {
+		batch, _ = e.git.BatchDiffNumstat(ctx, missing)
+	}
+	utils.Run(missing, func(rr git.RevRange) {
+		output, ok := batch[rr]
+		if !ok {
+			// Keep single-range reads cheap and isolate failures when a batch
+			// fails (for example, one stored divergence object was pruned).
+			var err error
+			output, err = e.git.RunGitCommandWithContext(ctx, "diff", "--numstat", rr.Base, rr.Head)
+			if err != nil {
+				return
+			}
+		}
+		e.diffStatsCache.Store(rr, parseDiffStat(output))
+	})
+	for _, rr := range missing {
+		if stat, ok := e.diffStatsCache.Load(rr); ok {
+			result[rr] = stat.(cachedDiffStat)
+		}
+	}
+	return result
+}

--- a/internal/engine/diff_stats_test.go
+++ b/internal/engine/diff_stats_test.go
@@ -1,0 +1,82 @@
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+type countingDiffRunner struct {
+	git.Runner
+	batches atomic.Int64
+	singles atomic.Int64
+	fail    bool
+}
+
+func (r *countingDiffRunner) BatchDiffNumstat(ctx context.Context, ranges []git.RevRange) (map[git.RevRange]string, error) {
+	r.batches.Add(1)
+	if r.fail {
+		return nil, fmt.Errorf("batch failed")
+	}
+	return r.Runner.BatchDiffNumstat(ctx, ranges)
+}
+
+func (r *countingDiffRunner) RunGitCommandWithContext(ctx context.Context, args ...string) (string, error) {
+	if len(args) > 1 && args[0] == "diff" && args[1] == "--numstat" {
+		r.singles.Add(1)
+	}
+	return r.Runner.RunGitCommandWithContext(ctx, args...)
+}
+
+func TestDiffReadersShareBatchAndCache(t *testing.T) {
+	t.Parallel()
+	for _, fail := range []bool{false, true} {
+		t.Run(fmt.Sprint(fail), func(t *testing.T) {
+			t.Parallel()
+			s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithLinearStack3()
+			r := &countingDiffRunner{Runner: s.Engine.Git(), fail: fail}
+			eng, err := engine.NewEngine(engine.Options{RepoRoot: s.Scene.Dir, Trunk: "main", Git: r})
+			require.NoError(t, err)
+			branches := engine.BranchesFromNames(eng, []string{"main", "a", "b", "c"})
+			stats := eng.BatchBranchStats(branches)
+			files := eng.BatchChangedFileCounts(context.Background(), branches)
+			diffs := eng.BatchDiffStats(branches)
+			require.EqualValues(t, 1, r.batches.Load())
+			if fail {
+				require.EqualValues(t, 3, r.singles.Load(), "failed batch falls back per distinct range")
+			} else {
+				require.Zero(t, r.singles.Load(), "cold stats should not spawn per-branch diffs")
+			}
+			for _, b := range branches {
+				name := b.GetName()
+				require.Equal(t, stats[name].LinesAdded, diffs[name].Added)
+				require.Equal(t, stats[name].LinesDeleted, diffs[name].Deleted)
+				if b.IsTrunk() {
+					require.Zero(t, files[name])
+					continue
+				}
+				base, err := eng.GetDivergencePoint(name)
+				require.NoError(t, err)
+				want, err := s.Engine.GetChangedFiles(context.Background(), git.RevRange{Base: base, Head: name})
+				require.NoError(t, err)
+				require.Equal(t, len(want), files[name])
+			}
+			// A new tip must not reuse the previous range's stats. A lone miss
+			// takes the cheap single-range path, without another batch setup.
+			s.Checkout("c").CommitChange("fresh.txt", "new file")
+			before := r.singles.Load()
+			updated := eng.BatchChangedFileCounts(context.Background(), branches)
+			require.Equal(t, files["c"]+1, updated["c"])
+			require.EqualValues(t, 1, r.batches.Load())
+			require.Equal(t, before+1, r.singles.Load())
+		})
+	}
+}

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -87,44 +87,6 @@ func (e *engineImpl) commitCountBetween(rr git.RevRange) (int, error) {
 	return count, nil
 }
 
-// diffStatsBetween returns the additions/deletions between two revisions, using
-// the (base, head)-keyed cache. It takes pre-resolved revisions so batched
-// callers (the Batch* readers) need not re-resolve a branch's head.
-func (e *engineImpl) diffStatsBetween(rr git.RevRange) (int, int, error) {
-	base, head := rr.Base, rr.Head
-	if head == base {
-		return 0, 0, nil
-	}
-
-	cacheKey := base + ":" + head
-	if v, ok := e.diffStatsCache.Load(cacheKey); ok {
-		stats := v.([2]int)
-		return stats[0], stats[1], nil
-	}
-
-	output, err := e.git.GetDiffNumstat(rr)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	added, deleted := 0, 0
-	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
-		if line == "" {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) >= 2 {
-			a, _ := strconv.Atoi(fields[0])
-			d, _ := strconv.Atoi(fields[1])
-			added += a
-			deleted += d
-		}
-	}
-
-	e.diffStatsCache.Store(cacheKey, [2]int{added, deleted})
-	return added, deleted, nil
-}
-
 // GetRecentTrunkCommits returns the most recent commits on the trunk branch,
 // including any stack trailer metadata embedded in consolidation merge commits.
 func (e *engineImpl) GetRecentTrunkCommits(count int) ([]git.RecentCommit, error) {

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -45,9 +45,9 @@ type engineImpl struct {
 	tempWorktreePrunedOnce bool
 
 	// Per-request caches for expensive git operations.
-	// Key: "base:head" (both are resolved SHAs); value type noted inline.
-	diffStatsCache   sync.Map // value: [2]int{added, deleted}
-	commitCountCache sync.Map // value: int
+	// Both caches use resolved SHAs so rewritten branches get fresh results.
+	diffStatsCache   sync.Map // key: git.RevRange; value: cachedDiffStat
+	commitCountCache sync.Map // key: "base:head"; value: int
 }
 
 // WorktreeSnapshot holds a deep copy of engine state for initializing worktree engines.

--- a/internal/git/diff_batch.go
+++ b/internal/git/diff_batch.go
@@ -1,0 +1,133 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// BatchDiffNumstat compares independent ranges with one diff-tree process.
+// It returns the same line-oriented numstat format as GetDiffNumstat. Callers
+// may fall back to individual reads on error; no partial results are returned.
+func (r *runner) BatchDiffNumstat(ctx context.Context, ranges []RevRange) (map[RevRange]string, error) {
+	result := make(map[RevRange]string, len(ranges))
+	if len(ranges) == 0 {
+		return result, nil
+	}
+
+	refs := make([]string, 0, len(ranges)*2)
+	seen := make(map[string]bool)
+	for _, rr := range ranges {
+		for _, ref := range []string{rr.Base, rr.Head} {
+			if ref == "" {
+				return nil, fmt.Errorf("batch diff requires explicit base and head")
+			}
+			if !seen[ref] {
+				refs = append(refs, ref)
+				seen[ref] = true
+			}
+		}
+	}
+	args := []string{"rev-parse", "--revs-only", "--end-of-options"}
+	for _, ref := range refs {
+		args = append(args, ref+"^{tree}")
+	}
+	out, err := r.RunGitCommandWithContext(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	shas := strings.Fields(out)
+	if len(shas) != len(refs) {
+		return nil, fmt.Errorf("batch diff resolved %d trees for %d refs", len(shas), len(refs))
+	}
+	trees := make(map[string]string, len(refs))
+	for i, ref := range refs {
+		trees[ref] = shas[i]
+	}
+
+	var input strings.Builder
+	sections := make(map[string]*strings.Builder)
+	keys := make(map[RevRange]string, len(ranges))
+	for _, rr := range ranges {
+		if trees[rr.Base] == trees[rr.Head] {
+			result[rr] = ""
+			continue
+		}
+		key := trees[rr.Base] + " " + trees[rr.Head]
+		keys[rr] = key
+		if sections[key] == nil {
+			sections[key] = &strings.Builder{}
+			input.WriteString(key + "\n")
+		}
+	}
+	if len(sections) == 0 {
+		return result, nil
+	}
+	options, err := r.batchDiffOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args = append([]string{"diff-tree", "--stdin", "-r", "--numstat"}, options...)
+	out, err = r.runGitInternal(ctx, input.String(), nil, false, args...)
+	if err != nil {
+		return nil, err
+	}
+	var current *strings.Builder
+	seenHeaders := make(map[string]bool, len(sections))
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if section := sections[line]; section != nil {
+			current = section
+			seenHeaders[line] = true
+		} else if current != nil && strings.Contains(line, "\t") {
+			current.WriteString(line + "\n")
+		} else {
+			return nil, fmt.Errorf("unexpected batch diff output %q", line)
+		}
+	}
+	if len(seenHeaders) != len(sections) {
+		return nil, fmt.Errorf("batch diff returned %d comparisons for %d ranges", len(seenHeaders), len(sections))
+	}
+	for rr, key := range keys {
+		result[rr] = strings.TrimSpace(sections[key].String())
+	}
+	return result, nil
+}
+
+// diff-tree does not apply these porcelain-only settings itself. Pass them
+// explicitly to retain git diff's rename/copy and submodule behavior.
+func (r *runner) batchDiffOptions(ctx context.Context) ([]string, error) {
+	const renamesEnabled = "true"
+	out, err := r.RunGitCommandRawWithContext(ctx, "config", "--null", "--get-regexp", `^diff\.(renames|ignoresubmodules)$`)
+	if err != nil && !isExitCode(err, 1) {
+		return nil, err
+	}
+	renames := renamesEnabled
+	ignoreSubmodules := ""
+	for entry := range strings.SplitSeq(out, "\x00") {
+		key, value, hasValue := strings.Cut(entry, "\n")
+		switch key {
+		case "diff.renames":
+			renames = strings.ToLower(value)
+			if !hasValue {
+				renames = renamesEnabled
+			}
+		case "diff.ignoresubmodules":
+			ignoreSubmodules = value
+		}
+	}
+	var options []string
+	switch renames {
+	case renamesEnabled, "yes", "on", "1":
+		options = append(options, "--find-renames")
+	case "false", "no", "off", "0", "":
+		options = append(options, "--no-renames")
+	case "copy", "copies":
+		options = append(options, "--find-copies")
+	default:
+		return nil, fmt.Errorf("unsupported diff.renames value %q", renames)
+	}
+	if ignoreSubmodules != "" {
+		options = append(options, "--ignore-submodules="+ignoreSubmodules)
+	}
+	return options, nil
+}

--- a/internal/git/diff_batch.go
+++ b/internal/git/diff_batch.go
@@ -7,7 +7,7 @@ import (
 )
 
 // BatchDiffNumstat compares independent ranges with one diff-tree process.
-// It returns the same line-oriented numstat format as GetDiffNumstat. Callers
+// It returns Git's line-oriented numstat format. Callers
 // may fall back to individual reads on error; no partial results are returned.
 func (r *runner) BatchDiffNumstat(ctx context.Context, ranges []RevRange) (map[RevRange]string, error) {
 	result := make(map[RevRange]string, len(ranges))

--- a/internal/git/diff_batch_test.go
+++ b/internal/git/diff_batch_test.go
@@ -55,7 +55,7 @@ func TestBatchDiffNumstatMatchesGitDiff(t *testing.T) {
 		require.Equal(t, before+1, logger.countDebugContaining("git diff-tree "), "one diff process for all ranges")
 		require.Len(t, got, 4)
 		for _, rr := range ranges {
-			want, err := r.GetDiffNumstat(rr)
+			want, err := r.RunGitCommandWithContext(ctx, "diff", "--numstat", rr.Base, rr.Head)
 			require.NoError(t, err)
 			require.Equal(t, want, got[rr], "%s with renames=%s", rr, setting)
 		}
@@ -102,7 +102,7 @@ func TestBatchDiffNumstatSubmoduleConfig(t *testing.T) {
 		require.NoError(t, r.SetConfig("diff.ignoreSubmodules", setting))
 		got, err := r.BatchDiffNumstat(ctx, []git.RevRange{rr})
 		require.NoError(t, err)
-		want, err := r.GetDiffNumstat(rr)
+		want, err := r.RunGitCommandWithContext(ctx, "diff", "--numstat", rr.Base, rr.Head)
 		require.NoError(t, err)
 		require.Equal(t, want, got[rr], "ignoreSubmodules=%s", setting)
 	}

--- a/internal/git/diff_batch_test.go
+++ b/internal/git/diff_batch_test.go
@@ -1,0 +1,109 @@
+package git_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+func TestBatchDiffNumstatMatchesGitDiff(t *testing.T) {
+	t.Parallel()
+	s := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	logger := &captureGitLogger{}
+	r := git.NewRunnerWithPath(s.Dir, logger)
+	ctx := context.Background()
+	write := func(name, content string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(s.Dir, name), []byte(content), 0600))
+	}
+	commit := func() string {
+		t.Helper()
+		require.NoError(t, s.Repo.RunGitCommand("add", "-A"))
+		require.NoError(t, s.Repo.RunGitCommand("commit", "-m", "fixture"))
+		sha, err := s.Repo.GetRevision("HEAD")
+		require.NoError(t, err)
+		return sha
+	}
+	initial, err := s.Repo.GetRevision("HEAD")
+	require.NoError(t, err)
+	write("old.txt", "first\nsecond\nthird\n")
+	write("binary", "\x00old")
+	write("copy-source", "one\ntwo\nthree\nfour\nfive\n")
+	base := commit()
+	require.NoError(t, os.Rename(filepath.Join(s.Dir, "old.txt"), filepath.Join(s.Dir, "new.txt")))
+	write("binary", "\x00new")
+	write("tabs\tand\nnewlines", "hello\n")
+	write("copy-target", "one\ntwo\nthree\nfour\nfive\n")
+	write("copy-source", "one\ntwo\nthree\nfour\nfive\nsix\n")
+	head := commit()
+	ranges := []git.RevRange{
+		{Base: base, Head: head}, {Base: initial, Head: head},
+		{Base: head, Head: base}, {Base: head, Head: head},
+		{Base: base, Head: head}, // duplicate comparison
+	}
+	for _, setting := range []string{"true", "false", "copies", ""} {
+		require.NoError(t, r.SetConfig("diff.renames", setting))
+		before := logger.countDebugContaining("git diff-tree ")
+		got, err := r.BatchDiffNumstat(ctx, ranges)
+		require.NoError(t, err)
+		require.Equal(t, before+1, logger.countDebugContaining("git diff-tree "), "one diff process for all ranges")
+		require.Len(t, got, 4)
+		for _, rr := range ranges {
+			want, err := r.GetDiffNumstat(rr)
+			require.NoError(t, err)
+			require.Equal(t, want, got[rr], "%s with renames=%s", rr, setting)
+		}
+	}
+
+	// Different commits with identical trees must still yield an empty result.
+	require.NoError(t, s.Repo.RunGitCommand("commit", "--allow-empty", "-m", "empty"))
+	empty, err := s.Repo.GetRevision("HEAD")
+	require.NoError(t, err)
+	got, err := r.BatchDiffNumstat(ctx, []git.RevRange{{Base: head, Head: empty}})
+	require.NoError(t, err)
+	require.Equal(t, map[git.RevRange]string{{Base: head, Head: empty}: ""}, got)
+
+	// The batch must not return plausible partial stats for an invalid range.
+	got, err = r.BatchDiffNumstat(ctx, append(ranges, git.RevRange{Base: base, Head: "no-such-ref"}))
+	require.Error(t, err)
+	require.Nil(t, got)
+	got, err = r.BatchDiffNumstat(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = r.BatchDiffNumstat(canceled, ranges)
+	require.Error(t, err)
+}
+
+func TestBatchDiffNumstatSubmoduleConfig(t *testing.T) {
+	t.Parallel()
+	s := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	r := git.NewRunnerWithPath(s.Dir, nil)
+	ctx := context.Background()
+	initial, err := s.Repo.GetRevision("HEAD")
+	require.NoError(t, err)
+	require.NoError(t, s.Repo.RunGitCommand("update-index", "--add", "--cacheinfo", "160000,"+initial+",sub"))
+	require.NoError(t, s.Repo.RunGitCommand("commit", "-m", "add submodule"))
+	base, err := s.Repo.GetRevision("HEAD")
+	require.NoError(t, err)
+	require.NoError(t, s.Repo.RunGitCommand("update-index", "--cacheinfo", "160000,"+base+",sub"))
+	require.NoError(t, s.Repo.RunGitCommand("commit", "-m", "advance submodule"))
+	head, err := s.Repo.GetRevision("HEAD")
+	require.NoError(t, err)
+	rr := git.RevRange{Base: base, Head: head}
+	for _, setting := range []string{"none", "all", "dirty", "untracked"} {
+		require.NoError(t, r.SetConfig("diff.ignoreSubmodules", setting))
+		got, err := r.BatchDiffNumstat(ctx, []git.RevRange{rr})
+		require.NoError(t, err)
+		want, err := r.GetDiffNumstat(rr)
+		require.NoError(t, err)
+		require.Equal(t, want, got[rr], "ignoreSubmodules=%s", setting)
+	}
+}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -110,6 +110,7 @@ type DiffOperations interface {
 	ShowDiff(ctx context.Context, left, right string, stat bool) (string, error)
 	ShowCommits(ctx context.Context, rr RevRange, patch, stat bool) (string, error)
 	GetDiffNumstat(rr RevRange) (string, error)
+	BatchDiffNumstat(ctx context.Context, ranges []RevRange) (map[RevRange]string, error)
 	GetStagedDiff(ctx context.Context, files ...string) (string, error)
 	GetUnstagedDiff(ctx context.Context, files ...string) (string, error)
 	// GetUnstagedDiffBinary is like GetUnstagedDiff but includes full binary

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -109,7 +109,6 @@ type DiffOperations interface {
 	GetChangedFiles(ctx context.Context, rr RevRange) ([]string, error)
 	ShowDiff(ctx context.Context, left, right string, stat bool) (string, error)
 	ShowCommits(ctx context.Context, rr RevRange, patch, stat bool) (string, error)
-	GetDiffNumstat(rr RevRange) (string, error)
 	BatchDiffNumstat(ctx context.Context, ranges []RevRange) (map[RevRange]string, error)
 	GetStagedDiff(ctx context.Context, files ...string) (string, error)
 	GetUnstagedDiff(ctx context.Context, files ...string) (string, error)

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -940,11 +940,6 @@ func (r *runner) GetReflog(ctx context.Context, count int, format string) (strin
 	return r.RunGitCommandWithContext(ctx, args...)
 }
 
-func (r *runner) GetDiffNumstat(rr RevRange) (string, error) {
-	base, head := rr.Base, rr.Head
-	return r.runGitCommandInternal(gitCmdDiff, "--numstat", base, head)
-}
-
 func (r *runner) GetCommitLog(sha, format string) (string, error) {
 	return r.runGitCommandInternal("log", "-1", "--format="+format, sha)
 }


### PR DESCRIPTION
Collect uncached divergence ranges before fetching numstat data. Reuse those
results for additions, deletions, and changed-file counts, with individual
fallback for batch failures and a cheap path for a single uncached range.

Remove the redundant GetDiffNumstat API. Tests compare against raw Git and
verify that the stats readers share a batch, preserve fallback, and refresh
when a branch tip changes. Commit counting remains independently cached.

Validation: engine tests confirm one cold diff batch shared by branch stats, line stats, and file counts; no individual diffs on success; fallback on batch failure; and refresh after a branch tip changes. Existing raw-Git comparison and divergence-base tests pass. `mise run check` and the final `mise run check:go` passed. Commit counting still uses per-range cached reads.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1746**
  * **PR #1749**
    * **PR #1748** 👈
      * **PR #1747**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->
