### PR TITLE
perf: batch worktree ownership lookups instead of per-branch git reads

### DIFF
--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -183,6 +183,18 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 // worktree. That full-stack deletion is delete's intentional cleanup workflow:
 // it removes the worktree registration after removing its stack.
 func managedCleanupAnchors(ctx *app.Context, toDelete engine.Branches) ([]string, error) {
+	// Resolve worktree ownership from a single ListManagedWorktrees call
+	// instead of one OwningWorktree call (two git reads each) per branch
+	// examined below, including every branch in the repo while checking anchor
+	// completeness.
+	worktreeByStackRoot, err := actions.WorktreesByStackRoot(ctx.Engine)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list managed worktrees: %w", err)
+	}
+	owningWorktree := func(branch engine.Branch) *engine.WorktreeInfo {
+		return worktreeByStackRoot[ctx.Engine.GetStackRootForBranch(branch)]
+	}
+
 	selected := make(map[string]bool, len(toDelete))
 	for _, branch := range toDelete {
 		selected[branch.GetName()] = true
@@ -190,11 +202,7 @@ func managedCleanupAnchors(ctx *app.Context, toDelete engine.Branches) ([]string
 
 	anchors := make(map[string]bool)
 	for _, branch := range toDelete {
-		owner, err := ctx.Engine.OwningWorktree(branch)
-		if err != nil {
-			return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branch.GetName(), err)
-		}
-		if owner != nil {
+		if owner := owningWorktree(branch); owner != nil {
 			anchors[owner.AnchorBranch] = true
 		}
 	}
@@ -206,11 +214,7 @@ func managedCleanupAnchors(ctx *app.Context, toDelete engine.Branches) ([]string
 			if candidate.IsWorktreeAnchor() {
 				continue
 			}
-			owner, err := ctx.Engine.OwningWorktree(candidate)
-			if err != nil {
-				return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", candidate.GetName(), err)
-			}
-			if owner != nil && owner.AnchorBranch == anchor && !selected[candidate.GetName()] {
+			if owner := owningWorktree(candidate); owner != nil && owner.AnchorBranch == anchor && !selected[candidate.GetName()] {
 				complete = false
 				break
 			}
@@ -222,10 +226,7 @@ func managedCleanupAnchors(ctx *app.Context, toDelete engine.Branches) ([]string
 
 	guarded := make([]engine.Branch, 0, len(toDelete))
 	for _, branch := range toDelete {
-		owner, err := ctx.Engine.OwningWorktree(branch)
-		if err != nil {
-			return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branch.GetName(), err)
-		}
+		owner := owningWorktree(branch)
 		if owner == nil || !anchors[owner.AnchorBranch] || !slices.Contains(cleanup, owner.AnchorBranch) {
 			guarded = append(guarded, branch)
 		}

--- a/internal/actions/worktree_ownership.go
+++ b/internal/actions/worktree_ownership.go
@@ -17,6 +17,13 @@ import (
 // Branch has no command context, and the same branch can be valid in one
 // worktree and invalid in another.
 func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
+	// Resolve ownership for every branch from a single ListManagedWorktrees
+	// call instead of one OwningWorktree call (two git reads each) per branch.
+	worktreeByStackRoot, err := WorktreesByStackRoot(ctx.Engine)
+	if err != nil {
+		return fmt.Errorf("cannot list managed worktrees: %w", err)
+	}
+
 	seen := make(map[string]struct{}, len(branches))
 	for _, branch := range branches {
 		branchName := branch.GetName()
@@ -28,10 +35,7 @@ func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
 		}
 		seen[branchName] = struct{}{}
 
-		owner, err := ctx.Engine.OwningWorktree(branch)
-		if err != nil {
-			return fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branchName, err)
-		}
+		owner := worktreeByStackRoot[ctx.Engine.GetStackRootForBranch(branch)]
 
 		if owner == nil {
 			if ctx.InManagedWorktree {
@@ -61,6 +65,22 @@ func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
 	}
 
 	return nil
+}
+
+// WorktreesByStackRoot indexes every managed worktree by its stack root
+// (anchor branch) from a single ListManagedWorktrees call, so callers
+// resolving ownership for many branches can avoid one OwningWorktree call
+// (two git reads each) per branch.
+func WorktreesByStackRoot(eng engine.Engine) (map[string]*engine.WorktreeInfo, error) {
+	worktrees, err := eng.ListManagedWorktrees()
+	if err != nil {
+		return nil, err
+	}
+	byStackRoot := make(map[string]*engine.WorktreeInfo, len(worktrees))
+	for i := range worktrees {
+		byStackRoot[worktrees[i].AnchorBranch] = &worktrees[i]
+	}
+	return byStackRoot, nil
 }
 
 // EnsureCanModifyNamesHere is the convenient form for operations that resolve


### PR DESCRIPTION
## Summary

- `EnsureCanModifyHere` — the worktree-ownership guard that runs before nearly every stack-mutating command (`create`, `modify`, `absorb`, `fold`, `squash`, `split`, `move`, `reorder`, `pluck`, `delete`, `track`) — called `OwningWorktree` once per branch it checked. Each call does two git reads (`GetRef` + `ReadBlob`).
- `delete`'s `managedCleanupAnchors` made this worse: for every anchor found, it called `OwningWorktree` again for *every branch in the repo* to determine whether a worktree's whole stack was being deleted.
- Both now resolve ownership from a single `ListManagedWorktrees` read, indexed by stack root (`WorktreesByStackRoot`, exported from `internal/actions`), and reused across every branch examined in the call — mirroring the same batching pattern already used in `internal/tui/tree_renderer.go`.
- No behavior change: same ownership semantics, just backed by one git call instead of O(branches) calls.

## Test plan

- `go build ./...`
- `go vet ./...`
- `go test ./internal/actions/...` (all packages pass, including `delete` and the `worktree_ownership_test.go` coverage for `EnsureCanModifyHere`)
- `go test ./internal/integration/...` (full suite, including all worktree/multiplayer scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTbBRxtwfJmqXH6n241sa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTbBRxtwfJmqXH6n241sa8)_